### PR TITLE
chore: fix npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.0.9",
+	"version": "1.0.19",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "everything-gemini-code",
-			"version": "1.0.9",
+			"version": "1.0.19",
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
@@ -15,7 +15,7 @@
 				"@eslint/js": "^9.39.2",
 				"eslint": "^9.39.2",
 				"globals": "^17.1.0",
-				"markdownlint-cli": "^0.47.0"
+				"markdownlint-cli": "^0.48.0"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -230,29 +230,6 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@isaacs/balanced-match": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-			"integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@isaacs/balanced-match": "^4.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -322,9 +299,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1157,9 +1134,9 @@
 			"license": "MIT"
 		},
 		"node_modules/markdown-it": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+			"integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1199,23 +1176,23 @@
 			}
 		},
 		"node_modules/markdownlint-cli": {
-			"version": "0.47.0",
-			"resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.47.0.tgz",
-			"integrity": "sha512-HOcxeKFAdDoldvoYDofd85vI8LgNWy8vmYpCwnlLV46PJcodmGzD7COSSBlhHwsfT4o9KrAStGodImVBus31Bg==",
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
+			"integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"commander": "~14.0.2",
+				"commander": "~14.0.3",
 				"deep-extend": "~0.6.0",
 				"ignore": "~7.0.5",
 				"js-yaml": "~4.1.1",
 				"jsonc-parser": "~3.3.1",
 				"jsonpointer": "~5.0.1",
-				"markdown-it": "~14.1.0",
+				"markdown-it": "~14.1.1",
 				"markdownlint": "~0.40.0",
-				"minimatch": "~10.1.1",
+				"minimatch": "~10.2.4",
 				"run-con": "~1.3.2",
-				"smol-toml": "~1.5.2",
+				"smol-toml": "~1.6.0",
 				"tinyglobby": "~0.2.15"
 			},
 			"bin": {
@@ -1223,6 +1200,29 @@
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/markdownlint-cli/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/ignore": {
@@ -1236,16 +1236,16 @@
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/minimatch": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-			"integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"@isaacs/brace-expansion": "^5.0.1"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -1795,9 +1795,9 @@
 			"license": "MIT"
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2026,9 +2026,9 @@
 			}
 		},
 		"node_modules/smol-toml": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-			"integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+			"integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@eslint/js": "^9.39.2",
 		"eslint": "^9.39.2",
 		"globals": "^17.1.0",
-		"markdownlint-cli": "^0.47.0"
+		"markdownlint-cli": "^0.48.0"
 	},
 	"overrides": {
 		"punycode": "$punycode",

--- a/workflows/build-fix.md
+++ b/workflows/build-fix.md
@@ -1,3 +1,7 @@
+---
+description: Fix build and TypeScript errors incrementally.
+---
+
 # Build and Fix
 
 Incrementally fix TypeScript and build errors:

--- a/workflows/checkpoint.md
+++ b/workflows/checkpoint.md
@@ -1,10 +1,14 @@
+---
+description: Create or verify a checkpoint in your workflow.
+---
+
 # Checkpoint Command
 
 Create or verify a checkpoint in your workflow.
 
 ## Usage
 
-`/checkpoint [create|verify|list] [name]`
+### /checkpoint [create|verify|list] [name]
 
 ## Create Checkpoint
 
@@ -32,6 +36,7 @@ When verifying against a checkpoint:
    - Coverage now vs then
 
 3. Report:
+
 ```
 CHECKPOINT COMPARISON: $NAME
 ============================
@@ -44,6 +49,7 @@ Build: [PASS/FAIL]
 ## List Checkpoints
 
 Show all checkpoints with:
+
 - Name
 - Timestamp
 - Git SHA
@@ -68,6 +74,7 @@ Typical checkpoint flow:
 ## Arguments
 
 $ARGUMENTS:
+
 - `create <name>` - Create named checkpoint
 - `verify <name>` - Verify against named checkpoint
 - `list` - Show all checkpoints

--- a/workflows/code-review.md
+++ b/workflows/code-review.md
@@ -1,3 +1,7 @@
+---
+description: Comprehensive security and quality review of uncommitted changes.
+---
+
 # Code Review
 
 Comprehensive security and quality review of uncommitted changes:
@@ -7,14 +11,16 @@ Comprehensive security and quality review of uncommitted changes:
 2. For each changed file, check for:
 
 **Security Issues (CRITICAL):**
+
 - Hardcoded credentials, API keys, tokens
 - SQL injection vulnerabilities
-- XSS vulnerabilities  
+- XSS vulnerabilities
 - Missing input validation
 - Insecure dependencies
 - Path traversal risks
 
 **Code Quality (HIGH):**
+
 - Functions > 50 lines
 - Files > 800 lines
 - Nesting depth > 4 levels
@@ -24,6 +30,7 @@ Comprehensive security and quality review of uncommitted changes:
 - Missing JSDoc for public APIs
 
 **Best Practices (MEDIUM):**
+
 - Mutation patterns (use immutable instead)
 - Emoji usage in code/comments
 - Missing tests for new code

--- a/workflows/eval.md
+++ b/workflows/eval.md
@@ -1,3 +1,7 @@
+---
+description: Manage eval-driven development workflow.
+---
+
 # Eval Command
 
 Manage eval-driven development workflow.
@@ -113,6 +117,7 @@ feature-export    [0/4 passing] NOT STARTED
 ## Arguments
 
 $ARGUMENTS:
+
 - `define <name>` - Create new eval definition
 - `check <name>` - Run and check evals
 - `report <name>` - Generate full report

--- a/workflows/learn.md
+++ b/workflows/learn.md
@@ -1,3 +1,7 @@
+---
+description: Extract reusable patterns from the session and save as skills.
+---
+
 # /learn - Extract Reusable Patterns
 
 Analyze the current session and extract any patterns worth saving as skills.

--- a/workflows/multi-backend.md
+++ b/workflows/multi-backend.md
@@ -1,3 +1,7 @@
+---
+description: Backend-focused development workflow (Research to Review).
+---
+
 # Backend - Backend-Focused Development
 
 Backend-focused workflow (Research → Ideation → Plan → Execute → Optimize → Review), Codex-led.
@@ -19,6 +23,7 @@ Backend-focused workflow (Research → Ideation → Plan → Execute → Optimiz
 You are the **Backend Orchestrator**, coordinating multi-model collaboration for server-side tasks (Research → Ideation → Plan → Execute → Optimize → Review).
 
 **Collaborative Models**:
+
 - **Codex** – Backend logic, algorithms (**Backend authority, trustworthy**)
 - **Gemini** – Frontend perspective (**Backend opinions for reference only**)
 - **Gemini (self)** – Orchestration, planning, execution, delivery
@@ -63,11 +68,11 @@ EOF",
 
 **Role Prompts**:
 
-| Phase | Codex |
-|-------|-------|
-| Analysis | `~/.gemini/.ccg/prompts/codex/analyzer.md` |
+| Phase    | Codex                                       |
+| -------- | ------------------------------------------- |
+| Analysis | `~/.gemini/.ccg/prompts/codex/analyzer.md`  |
 | Planning | `~/.gemini/.ccg/prompts/codex/architect.md` |
-| Review | `~/.gemini/.ccg/prompts/codex/reviewer.md` |
+| Review   | `~/.gemini/.ccg/prompts/codex/reviewer.md`  |
 
 **Session Reuse**: Each call returns `SESSION_ID: xxx`, use `resume xxx` for subsequent phases. Save `CODEX_SESSION` in Phase 2, use `resume` in Phases 3 and 5.
 
@@ -99,6 +104,7 @@ EOF",
 `[Mode: Ideation]` - Codex-led analysis
 
 **MUST call Codex** (follow call specification above):
+
 - ROLE_FILE: `~/.gemini/.ccg/prompts/codex/analyzer.md`
 - Requirement: Enhanced requirement (or $ARGUMENTS if not enhanced)
 - Context: Project context from Phase 1
@@ -113,6 +119,7 @@ Output solutions (at least 2), wait for user selection.
 `[Mode: Plan]` - Codex-led planning
 
 **MUST call Codex** (use `resume <CODEX_SESSION>` to reuse session):
+
 - ROLE_FILE: `~/.gemini/.ccg/prompts/codex/architect.md`
 - Requirement: User's selected solution
 - Context: Analysis results from Phase 2
@@ -133,6 +140,7 @@ Gemini synthesizes plan, save to `.gemini/plan/task-name.md` after user approval
 `[Mode: Optimize]` - Codex-led review
 
 **MUST call Codex** (follow call specification above):
+
 - ROLE_FILE: `~/.gemini/.ccg/prompts/codex/reviewer.md`
 - Requirement: Review the following backend code changes
 - Context: git diff or code content

--- a/workflows/multi-execute.md
+++ b/workflows/multi-execute.md
@@ -1,3 +1,7 @@
+---
+description: Multi-model collaborative prototype implementation and auditing.
+---
+
 # Execute - Multi-Model Collaborative Execution
 
 Multi-model collaborative execution - Get prototype from plan → Gemini refactors and implements → Multi-model audit and delivery.

--- a/workflows/multi-frontend.md
+++ b/workflows/multi-frontend.md
@@ -1,3 +1,7 @@
+---
+description: Frontend-focused development workflow (Research to Review).
+---
+
 # Frontend - Frontend-Focused Development
 
 Frontend-focused workflow (Research → Ideation → Plan → Execute → Optimize → Review), Gemini-led.
@@ -19,6 +23,7 @@ Frontend-focused workflow (Research → Ideation → Plan → Execute → Optimi
 You are the **Frontend Orchestrator**, coordinating multi-model collaboration for UI/UX tasks (Research → Ideation → Plan → Execute → Optimize → Review).
 
 **Collaborative Models**:
+
 - **Gemini** – Frontend UI/UX (**Frontend authority, trustworthy**)
 - **Codex** – Backend perspective (**Frontend opinions for reference only**)
 - **Gemini (self)** – Orchestration, planning, execution, delivery
@@ -63,11 +68,11 @@ EOF",
 
 **Role Prompts**:
 
-| Phase | Gemini |
-|-------|--------|
-| Analysis | `~/.gemini/.ccg/prompts/gemini/analyzer.md` |
+| Phase    | Gemini                                       |
+| -------- | -------------------------------------------- |
+| Analysis | `~/.gemini/.ccg/prompts/gemini/analyzer.md`  |
 | Planning | `~/.gemini/.ccg/prompts/gemini/architect.md` |
-| Review | `~/.gemini/.ccg/prompts/gemini/reviewer.md` |
+| Review   | `~/.gemini/.ccg/prompts/gemini/reviewer.md`  |
 
 **Session Reuse**: Each call returns `SESSION_ID: xxx`, use `resume xxx` for subsequent phases. Save `GEMINI_SESSION` in Phase 2, use `resume` in Phases 3 and 5.
 
@@ -99,6 +104,7 @@ EOF",
 `[Mode: Ideation]` - Gemini-led analysis
 
 **MUST call Gemini** (follow call specification above):
+
 - ROLE_FILE: `~/.gemini/.ccg/prompts/gemini/analyzer.md`
 - Requirement: Enhanced requirement (or $ARGUMENTS if not enhanced)
 - Context: Project context from Phase 1
@@ -113,6 +119,7 @@ Output solutions (at least 2), wait for user selection.
 `[Mode: Plan]` - Gemini-led planning
 
 **MUST call Gemini** (use `resume <GEMINI_SESSION>` to reuse session):
+
 - ROLE_FILE: `~/.gemini/.ccg/prompts/gemini/architect.md`
 - Requirement: User's selected solution
 - Context: Analysis results from Phase 2
@@ -133,6 +140,7 @@ Gemini synthesizes plan, save to `.gemini/plan/task-name.md` after user approval
 `[Mode: Optimize]` - Gemini-led review
 
 **MUST call Gemini** (follow call specification above):
+
 - ROLE_FILE: `~/.gemini/.ccg/prompts/gemini/reviewer.md`
 - Requirement: Review the following frontend code changes
 - Context: git diff or code content

--- a/workflows/multi-plan.md
+++ b/workflows/multi-plan.md
@@ -1,3 +1,7 @@
+---
+description: Multi-model collaborative context analysis and planning.
+---
+
 # Plan - Multi-Model Collaborative Planning
 
 Multi-model collaborative planning - Context retrieval + Dual-model analysis → Generate step-by-step implementation plan.
@@ -198,7 +202,7 @@ Synthesize both analyses, generate **Step-by-step Implementation Plan**:
 2. Save plan to `.gemini/plan/<feature-name>.md` (extract feature name from requirement, e.g., `user-auth`, `payment-module`)
 3. Output prompt in **bold text** (MUST use actual saved file path):
 
-   ---
+   ***
 
    **Plan generated and saved to `.gemini/plan/actual-feature-name.md`**
 
@@ -210,7 +214,7 @@ Synthesize both analyses, generate **Step-by-step Implementation Plan**:
    /ccg:execute .gemini/plan/actual-feature-name.md
    ```
 
-   ---
+   ***
 
    **NOTE**: The `actual-feature-name.md` above MUST be replaced with the actual saved filename!
 

--- a/workflows/multi-workflow.md
+++ b/workflows/multi-workflow.md
@@ -1,3 +1,7 @@
+---
+description: Multi-model development with intelligent backend/frontend routing.
+---
+
 # Workflow - Multi-Model Collaborative Development
 
 Multi-model collaborative development workflow (Research → Ideation → Plan → Execute → Optimize → Review), with intelligent routing: Frontend → Gemini, Backend → Codex.

--- a/workflows/orchestrate.md
+++ b/workflows/orchestrate.md
@@ -1,3 +1,7 @@
+---
+description: Sequential multi-agent workflow for complex task execution.
+---
+
 # Orchestrate Command
 
 Sequential agent workflow for complex tasks.
@@ -9,25 +13,33 @@ Sequential agent workflow for complex tasks.
 ## Workflow Types
 
 ### feature
+
 Full feature implementation workflow:
+
 ```
 planner -> tdd-guide -> code-reviewer -> security-reviewer
 ```
 
 ### bugfix
+
 Bug investigation and fix workflow:
+
 ```
 explorer -> tdd-guide -> code-reviewer
 ```
 
 ### refactor
+
 Safe refactoring workflow:
+
 ```
 architect -> code-reviewer -> tdd-guide
 ```
 
 ### security
+
 Security-focused review:
+
 ```
 security-reviewer -> code-reviewer -> architect
 ```
@@ -151,6 +163,7 @@ Combine outputs into single report
 ## Arguments
 
 $ARGUMENTS:
+
 - `feature <description>` - Full feature workflow
 - `bugfix <description>` - Bug fix workflow
 - `refactor <description>` - Refactoring workflow

--- a/workflows/pm2.md
+++ b/workflows/pm2.md
@@ -1,3 +1,7 @@
+---
+description: Project analysis and PM2 service command generation.
+---
+
 # PM2 Init
 
 Auto-analyze project and generate PM2 service commands.

--- a/workflows/refactor-clean.md
+++ b/workflows/refactor-clean.md
@@ -1,3 +1,7 @@
+---
+description: Identify and remove dead code with safe test verification.
+---
+
 # Refactor Clean
 
 Safely identify and remove dead code with test verification:

--- a/workflows/sessions.md
+++ b/workflows/sessions.md
@@ -1,3 +1,7 @@
+---
+description: Manage Gemini CLI session history, listing, and loading.
+---
+
 # Sessions Command
 
 Manage Gemini CLI session history - list, load, alias, and edit sessions stored in `~/.gemini/sessions/`.
@@ -21,6 +25,7 @@ Display all sessions with metadata, filtering, and pagination.
 ```
 
 **Script:**
+
 ```bash
 node -e "
 const sm = require('./scripts/lib/session-manager');
@@ -60,6 +65,7 @@ Load and display a session's content (by ID or alias).
 ```
 
 **Script:**
+
 ```bash
 node -e "
 const sm = require('./scripts/lib/session-manager');
@@ -121,6 +127,7 @@ Create a memorable alias for a session.
 ```
 
 **Script:**
+
 ```bash
 node -e "
 const sm = require('./scripts/lib/session-manager');
@@ -161,6 +168,7 @@ Delete an existing alias.
 ```
 
 **Script:**
+
 ```bash
 node -e "
 const aa = require('./scripts/lib/session-aliases');
@@ -190,6 +198,7 @@ Show detailed information about a session.
 ```
 
 **Script:**
+
 ```bash
 node -e "
 const sm = require('./scripts/lib/session-manager');
@@ -237,6 +246,7 @@ Show all session aliases.
 ```
 
 **Script:**
+
 ```bash
 node -e "
 const aa = require('./scripts/lib/session-aliases');
@@ -263,6 +273,7 @@ if (aliases.length === 0) {
 ## Arguments
 
 $ARGUMENTS:
+
 - `list [options]` - List sessions
   - `--limit <n>` - Max sessions to show (default: 50)
   - `--date <YYYY-MM-DD>` - Filter by date

--- a/workflows/test-coverage.md
+++ b/workflows/test-coverage.md
@@ -1,3 +1,7 @@
+---
+description: Analyze test coverage and generate missing unit tests.
+---
+
 # Test Coverage
 
 Analyze test coverage and generate missing tests:
@@ -21,6 +25,7 @@ Analyze test coverage and generate missing tests:
 7. Ensure project reaches 80%+ overall coverage
 
 Focus on:
+
 - Happy path scenarios
 - Error handling
 - Edge cases (null, undefined, empty)

--- a/workflows/update-codemaps.md
+++ b/workflows/update-codemaps.md
@@ -1,3 +1,7 @@
+---
+description: Analyze codebase structure and update architecture docs.
+---
+
 # Update Codemaps
 
 Analyze the codebase structure and update architecture documentation:
@@ -5,7 +9,7 @@ Analyze the codebase structure and update architecture documentation:
 1. Scan all source files for imports, exports, and dependencies
 2. Generate token-lean codemaps in the following format:
    - codemaps/architecture.md - Overall architecture
-   - codemaps/backend.md - Backend structure  
+   - codemaps/backend.md - Backend structure
    - codemaps/frontend.md - Frontend structure
    - codemaps/data.md - Data models and schemas
 

--- a/workflows/update-docs.md
+++ b/workflows/update-docs.md
@@ -1,3 +1,7 @@
+---
+description: Sync documentation from source-of-truth repositories.
+---
+
 # Update Documentation
 
 Sync documentation from source-of-truth:

--- a/workflows/verify.md
+++ b/workflows/verify.md
@@ -1,3 +1,7 @@
+---
+description: Run comprehensive verification on the current codebase state.
+---
+
 # Verification Command
 
 Run comprehensive verification on current codebase state.
@@ -53,6 +57,7 @@ If any critical issues, list them with fix suggestions.
 ## Arguments
 
 $ARGUMENTS can be:
+
 - `quick` - Only build + types
 - `full` - All checks (default)
 - `pre-commit` - Checks relevant for commits


### PR DESCRIPTION
This PR resolves the minimatch ReDoS vulnerabilities flagged by npm audit which was causing the Scheduled Maintenance GitHub Actions workflow to fail. It ran npm audit fix --force which upgraded markdownlint-cli to v0.48.0 to resolve the dependencies.