### PR TITLE
ci: update auto-release workflow with bot name, CI gate, and bypass token

### DIFF
--- a/.github/workflows/auto-release-on-merge.yml
+++ b/.github/workflows/auto-release-on-merge.yml
@@ -1,7 +1,10 @@
 name: Auto Release on Main
 
 on:
-  push:
+  workflow_run:
+    workflows: ['Gemini CI']
+    types:
+      - completed
     branches:
       - main
 
@@ -10,9 +13,10 @@ permissions:
 
 jobs:
   bump-and-release:
-    if: "!startsWith(github.event.head_commit.message, 'chore: bump extension version')"
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      !startsWith(github.event.workflow_run.head_commit.message, 'chore: bump extension version')
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,8 +25,8 @@ jobs:
 
       - name: Setup Git
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-release-bot"
+          git config --global user.email "github-release-bot@users.noreply.github.com"
 
       - name: Bump, Commit, Tag, and Push
         id: bump

--- a/workflows/multi-plan.md
+++ b/workflows/multi-plan.md
@@ -202,7 +202,7 @@ Synthesize both analyses, generate **Step-by-step Implementation Plan**:
 2. Save plan to `.gemini/plan/<feature-name>.md` (extract feature name from requirement, e.g., `user-auth`, `payment-module`)
 3. Output prompt in **bold text** (MUST use actual saved file path):
 
-   ***
+   ---
 
    **Plan generated and saved to `.gemini/plan/actual-feature-name.md`**
 
@@ -214,7 +214,7 @@ Synthesize both analyses, generate **Step-by-step Implementation Plan**:
    /ccg:execute .gemini/plan/actual-feature-name.md
    ```
 
-   ***
+   ---
 
    **NOTE**: The `actual-feature-name.md` above MUST be replaced with the actual saved filename!
 


### PR DESCRIPTION
## 변경 사항

### 1. 자동 배포 트리거 변경 (배포 안전장치 추가)
- `on: push` → `on: workflow_run` 으로 변경
- CI (`Gemini CI`)가 **성공적으로 완료**된 경우에만 버전업 및 배포가 진행됩니다
- CI 실패 시 배포가 자동으로 중단됩니다

### 2. 봇 이름 변경
- `github-actions[bot]` → `github-release-bot` 으로 변경

### 3. 브랜치 보호 규칙 우회 (RELEASE_TOKEN 사용)
- Checkout 시 `secrets.RELEASE_TOKEN`을 사용하여 보호된 `main` 브랜치에 직접 커밋 및 태그 푸시가 가능하도록 설정

### 4. 마크다운 린트 에러 수정
- `workflows/multi-plan.md` 에서 `***` → `---` 변경 (MD035 rule)

## 사전 조건
- GitHub 저장소 Settings → Secrets → `RELEASE_TOKEN` (repo 권한의 PAT) 이 등록되어 있어야 합니다