### PR TITLE
chore: release v1.0.21

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.0.19",
+	"version": "1.0.21",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.0.19",
+	"version": "1.0.21",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
This PR was generated manually via workflow_dispatch to bump the version to **v1.0.21**.

⚠️ **Note:** Merging this PR will NOT automatically trigger the release tag. Only workflow_dispatch handles it now, or you can merge this and then manually tag/release.

_Wait, if it's manual, we need to merge this PR to get the version bumped in main. The release action should probably run when this PR merges..._