### PR TITLE
chore(ci): update release PR branch name and skip CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
-          commit-message: 'chore: bump extension version to ${{ steps.version.outputs.RELEASE_TAG }}'
-          branch: 'chore/release-${{ steps.version.outputs.RELEASE_TAG }}'
+          commit-message: 'chore: bump extension version to ${{ steps.version.outputs.RELEASE_TAG }} [skip ci]'
+          branch: 'release/${{ steps.version.outputs.RELEASE_TAG }}'
           title: 'chore: release ${{ steps.version.outputs.RELEASE_TAG }}'
           body: |
             This PR was generated manually via workflow_dispatch to bump the version to **${{ steps.version.outputs.RELEASE_TAG }}**.


### PR DESCRIPTION
This PR updates the branch naming convention for automated release PRs from `chore/release-vX.Y.Z` to `release/vX.Y.Z`. It also adds `[skip ci]` to the automated commit message to prevent the build CI from running unnecessarily on just a version bump.