### PR TITLE
fix: resolve high severity flatted vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.0.19",
+	"version": "1.0.22",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "everything-gemini-code",
-			"version": "1.0.19",
+			"version": "1.0.22",
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
@@ -818,9 +818,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+			"integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
 			"dev": true,
 			"license": "ISC"
 		},


### PR DESCRIPTION
Update flatted 3.3.3 → 3.4.1 to fix unbounded recursion DoS in parse() (GHSA-25h7-pfq9-p65f). npm audit now passes cleanly.