### PR TITLE
fix: correct invalid Gemini CLI tool names in agents and docs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -54,8 +54,9 @@ reviews:
         is consistent and shell snippets are safely quoted.
     - path: "skills/**/*.md"
       instructions: |
-        Skill definitions. Check that frontmatter includes `name` and `description`,
-        and that "When to Use" / "Ideal For" sections are present and specific.
+        Skill definitions. Frontmatter must include `name` and `description`.
+        The document body (not the frontmatter) should contain a "When to Use"
+        or "Ideal For" section with specific, actionable trigger conditions.
     - path: "hooks/**"
       instructions: |
         Hook scripts and hooks.json. Hooks run automatically on tool events —
@@ -63,9 +64,9 @@ reviews:
         and that exit codes are intentional.
     - path: "scripts/**"
       instructions: |
-        Shell scripts must use `set -e`, quote all variables, and avoid
-        interpolating shell variables into `node -e` strings (use `process.env`
-        instead). JS scripts target Node.js 20+.
+        Shell scripts must use `set -euo pipefail`, quote all variables, and
+        avoid interpolating shell variables into `node -e` strings (use
+        `process.env` instead). JS scripts target Node.js 20+.
     - path: "rules/**/*.md"
       instructions: |
         Coding rules shipped to end users' ~/.gemini/rules/. Cross-references

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,12 +37,17 @@ reviews:
   path_instructions:
     - path: "agents/**/*.md"
       instructions: |
-        Gemini CLI agent definitions. The YAML frontmatter `tools:` array MUST use
-        valid Gemini CLI built-in tool names only: read_file, read_many_files,
-        write_file, replace, glob, search_file_content, list_directory,
-        run_shell_command, save_memory, web_fetch, google_web_search. Reject
-        Claude-style names like `search_files`, `replace_in_file`, `Read`, `Edit`.
-        Each agent must have `name` and `description` in frontmatter.
+        Gemini CLI agent definitions. The YAML frontmatter `tools:` array must
+        contain either:
+          (a) a valid Gemini CLI built-in tool: read_file, read_many_files,
+              write_file, replace, glob, search_file_content, list_directory,
+              run_shell_command, save_memory, web_fetch, google_web_search; or
+          (b) an MCP tool in the form `mcp__<server>__<tool_name>`.
+        Reject Claude-style names like `search_files`, `replace_in_file`, `Read`,
+        `Edit`. Also flag when the agent body references MCP tools (e.g. Slack,
+        Context7) that are not declared in the frontmatter `tools:` array — the
+        agent will be unable to call them at runtime. Each agent must have `name`
+        and `description` in frontmatter.
     - path: "commands/**/*.toml"
       instructions: |
         Gemini CLI command definitions in TOML format. Verify command metadata

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,109 @@
+language: "en-US"
+
+tone_instructions: |
+  Be concise and direct. Focus on bugs and security issues over style.
+
+early_access: true
+enable_free_tier: true
+
+reviews:
+  profile: "assertive"
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    ignore_title_keywords:
+      - "bump version"
+      - "release"
+      - "chore: bump"
+
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: false
+  sequence_diagrams: false
+
+  request_changes_workflow: true
+  suggested_labels: true
+  suggested_reviewers: false
+  auto_apply_labels: false
+
+  path_filters:
+    - "!node_modules/**"
+    - "!package-lock.json"
+    - "!*.lock"
+    - "!.DS_Store"
+
+  path_instructions:
+    - path: "agents/**/*.md"
+      instructions: |
+        Gemini CLI agent definitions. The YAML frontmatter `tools:` array MUST use
+        valid Gemini CLI built-in tool names only: read_file, read_many_files,
+        write_file, replace, glob, search_file_content, list_directory,
+        run_shell_command, save_memory, web_fetch, google_web_search. Reject
+        Claude-style names like `search_files`, `replace_in_file`, `Read`, `Edit`.
+        Each agent must have `name` and `description` in frontmatter.
+    - path: "commands/**/*.toml"
+      instructions: |
+        Gemini CLI command definitions in TOML format. Verify command metadata
+        is consistent and shell snippets are safely quoted.
+    - path: "skills/**/*.md"
+      instructions: |
+        Skill definitions. Check that frontmatter includes `name` and `description`,
+        and that "When to Use" / "Ideal For" sections are present and specific.
+    - path: "hooks/**"
+      instructions: |
+        Hook scripts and hooks.json. Hooks run automatically on tool events —
+        any failure impacts all sessions. Verify error handling, quiet logging,
+        and that exit codes are intentional.
+    - path: "scripts/**"
+      instructions: |
+        Shell scripts must use `set -e`, quote all variables, and avoid
+        interpolating shell variables into `node -e` strings (use `process.env`
+        instead). JS scripts target Node.js 20+.
+    - path: "rules/**/*.md"
+      instructions: |
+        Coding rules shipped to end users' ~/.gemini/rules/. Cross-references
+        between `common/` and language-specific files must use relative paths
+        (`../common/xxx.md`) and those targets must exist.
+    - path: "docs/**/*.md"
+      instructions: |
+        User-facing documentation. Tool-name mapping tables (Claude Code ↔ Gemini
+        CLI) must list only valid Gemini CLI tool names — incorrect mappings here
+        propagate into agent/skill definitions.
+    - path: "**/*.js"
+      instructions: |
+        Node.js 20+ project. Use `node:` prefix for built-in modules. Avoid
+        mutation — prefer spread/immutable patterns. Handle errors explicitly;
+        never swallow silently.
+
+  labeling_instructions:
+    - label: "security"
+      instructions: "Changes to hooks, scripts executing shell commands, or handling of user config/credential paths"
+    - label: "breaking"
+      instructions: "Changes to command names, agent tool names, hook event contracts, or public file layout under ~/.gemini/"
+    - label: "agents"
+      instructions: "Changes under agents/"
+    - label: "skills"
+      instructions: "Changes under skills/"
+    - label: "commands"
+      instructions: "Changes under commands/"
+    - label: "docs"
+      instructions: "Changes under docs/ or top-level markdown files only"
+
+  tools:
+    shellcheck:
+      enabled: true
+    gitleaks:
+      enabled: true
+    markdownlint:
+      enabled: true
+    eslint:
+      enabled: true
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: "local"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,9 +108,9 @@ If you are migrating agents from Claude Code:
 |-------------|------------|
 | `Read` | `read_file` |
 | `Write` | `write_file` |
-| `Edit` | `replace_in_file` |
+| `Edit` | `replace` |
 | `Bash` | `run_shell_command` |
-| `Grep` | `search_files` |
+| `Grep` | `search_file_content` |
 | `Glob` | `list_directory` |
 | `WebSearch` | `google_web_search` |
 

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Software architecture specialist for system design, scalability, and technical decision-making. Use PROACTIVELY when planning new features, refactoring large systems, or making architectural decisions.
-tools: ["read_file", "search_files", "list_directory"]
+tools: ["read_file", "search_file_content", "list_directory"]
 ---
 
 You are a senior software architect specializing in scalable, maintainable system design.

--- a/agents/chief-of-staff.md
+++ b/agents/chief-of-staff.md
@@ -1,7 +1,7 @@
 ---
 name: chief-of-staff
 description: Personal communication chief of staff that triages email, Slack, LINE, and Messenger. Classifies messages into 4 tiers (skip/info_only/meeting_info/action_required), generates draft replies, and enforces post-send follow-through via hooks. Use when managing multi-channel communication workflows.
-tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace", "write_file", "mcp__slack__conversations_search_messages", "mcp__slack__channels_list", "mcp__slack__conversations_history"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace", "write_file", "mcp__slack__conversations_search_messages", "mcp__slack__channels_list", "mcp__slack__conversations_history", "mcp__slack__conversations_add_message"]
 ---
 
 You are a personal chief of staff that manages all communication channels — email, Slack, LINE, Messenger, and calendar — through a unified triage pipeline.

--- a/agents/chief-of-staff.md
+++ b/agents/chief-of-staff.md
@@ -1,7 +1,7 @@
 ---
 name: chief-of-staff
 description: Personal communication chief of staff that triages email, Slack, LINE, and Messenger. Classifies messages into 4 tiers (skip/info_only/meeting_info/action_required), generates draft replies, and enforces post-send follow-through via hooks. Use when managing multi-channel communication workflows.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command", "replace_in_file", "write_file"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace", "write_file"]
 ---
 
 You are a personal chief of staff that manages all communication channels — email, Slack, LINE, Messenger, and calendar — through a unified triage pipeline.

--- a/agents/chief-of-staff.md
+++ b/agents/chief-of-staff.md
@@ -1,7 +1,7 @@
 ---
 name: chief-of-staff
 description: Personal communication chief of staff that triages email, Slack, LINE, and Messenger. Classifies messages into 4 tiers (skip/info_only/meeting_info/action_required), generates draft replies, and enforces post-send follow-through via hooks. Use when managing multi-channel communication workflows.
-tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace", "write_file"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace", "write_file", "mcp__slack__conversations_search_messages", "mcp__slack__channels_list", "mcp__slack__conversations_history"]
 ---
 
 You are a personal chief of staff that manages all communication channels — email, Slack, LINE, Messenger, and calendar — through a unified triage pipeline.

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -1,7 +1,7 @@
 ---
 name: code-architect
 description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing implementation blueprints with concrete files, interfaces, data flow, and build order.
-tools: [read_file, search_files, list_directory, run_shell_command]
+tools: [read_file, search_file_content, list_directory, run_shell_command]
 ---
 
 # Code Architect Agent

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -1,7 +1,7 @@
 ---
 name: code-explorer
 description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, and documenting dependencies to inform new development.
-tools: [read_file, search_files, list_directory, run_shell_command]
+tools: [read_file, search_file_content, list_directory, run_shell_command]
 ---
 
 # Code Explorer Agent

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code. MUST BE USED for all code changes.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command"]
 ---
 
 You are a senior code reviewer ensuring high standards of code quality and security.

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving behavior. Focus on recently modified code unless instructed otherwise.
-tools: [read_file, write_file, replace_in_file, run_shell_command, search_files, list_directory]
+tools: [read_file, write_file, replace, run_shell_command, search_file_content, list_directory]
 ---
 
 # Code Simplifier Agent

--- a/agents/comment-analyzer.md
+++ b/agents/comment-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: comment-analyzer
 description: Analyze code comments for accuracy, completeness, maintainability, and comment rot risk.
-tools: [read_file, search_files, list_directory, run_shell_command]
+tools: [read_file, search_file_content, list_directory, run_shell_command]
 ---
 
 # Comment Analyzer Agent

--- a/agents/conversation-analyzer.md
+++ b/agents/conversation-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: conversation-analyzer
 description: Use this agent when analyzing conversation transcripts to find behaviors worth preventing with hooks. Triggered by /hookify without arguments.
-tools: [read_file, search_files]
+tools: [read_file, search_file_content]
 ---
 
 # Conversation Analyzer Agent

--- a/agents/cpp-build-resolver.md
+++ b/agents/cpp-build-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: cpp-build-resolver
 description: C++ build, CMake, and compilation error resolution specialist. Fixes build errors, linker issues, and template errors with minimal changes. Use when C++ builds fail.
-tools: ["read_file", "write_file", "replace_in_file", "run_shell_command", "search_files", "list_directory"]
+tools: ["read_file", "write_file", "replace", "run_shell_command", "search_file_content", "list_directory"]
 ---
 
 # C++ Build Error Resolver

--- a/agents/cpp-reviewer.md
+++ b/agents/cpp-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: cpp-reviewer
 description: Expert C++ code reviewer specializing in memory safety, modern C++ idioms, concurrency, and performance. Use for all C++ code changes. MUST BE USED for C++ projects.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command"]
 ---
 
 You are a senior C++ code reviewer ensuring high standards of modern C++ and best practices.

--- a/agents/csharp-reviewer.md
+++ b/agents/csharp-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: csharp-reviewer
 description: Expert C# code reviewer specializing in .NET conventions, async patterns, security, nullable reference types, and performance. Use for all C# code changes. MUST BE USED for C# projects.
-tools: [read_file, search_files, list_directory, run_shell_command]
+tools: [read_file, search_file_content, list_directory, run_shell_command]
 ---
 
 You are a senior C# code reviewer ensuring high standards of idiomatic .NET code and best practices.

--- a/agents/dart-build-resolver.md
+++ b/agents/dart-build-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: dart-build-resolver
 description: Dart/Flutter build, analysis, and dependency error resolution specialist. Fixes `dart analyze` errors, Flutter compilation failures, pub dependency conflicts, and build_runner issues with minimal, surgical changes. Use when Dart/Flutter builds fail.
-tools: [read_file, write_file, replace_in_file, run_shell_command, search_files, list_directory]
+tools: [read_file, write_file, replace, run_shell_command, search_file_content, list_directory]
 ---
 
 # Dart/Flutter Build Error Resolver

--- a/agents/docs-lookup.md
+++ b/agents/docs-lookup.md
@@ -1,7 +1,7 @@
 ---
 name: docs-lookup
 description: When the user asks how to use a library, framework, or API or needs up-to-date code examples, use Context7 MCP to fetch current documentation and return answers with examples. Invoke for docs/API/setup questions.
-tools: ["read_file", "search_files", "mcp__context7__resolve-library-id", "mcp__context7__query-docs"]
+tools: ["read_file", "search_file_content", "mcp__context7__resolve-library-id", "mcp__context7__query-docs"]
 ---
 
 You are a documentation specialist. You answer questions about libraries, frameworks, and APIs using current documentation fetched via the Context7 MCP (resolve-library-id and query-docs), not training data.

--- a/agents/flutter-reviewer.md
+++ b/agents/flutter-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: flutter-reviewer
 description: Flutter and Dart code reviewer. Reviews Flutter code for widget best practices, state management patterns, Dart idioms, performance pitfalls, accessibility, and clean architecture violations. Library-agnostic — works with any state management solution and tooling.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command"]
 ---
 
 You are a senior Flutter and Dart code reviewer ensuring idiomatic, performant, and maintainable code.

--- a/agents/gan-evaluator.md
+++ b/agents/gan-evaluator.md
@@ -1,7 +1,7 @@
 ---
 name: gan-evaluator
 description: "GAN Harness — Evaluator agent. Tests the live running application via Playwright, scores against rubric, and provides actionable feedback to the Generator."
-tools: [read_file, write_file, run_shell_command, search_files, list_directory]
+tools: [read_file, write_file, run_shell_command, search_file_content, list_directory]
 color: red
 ---
 

--- a/agents/gan-generator.md
+++ b/agents/gan-generator.md
@@ -1,7 +1,7 @@
 ---
 name: gan-generator
 description: "GAN Harness — Generator agent. Implements features according to the spec, reads evaluator feedback, and iterates until quality threshold is met."
-tools: [read_file, write_file, replace_in_file, run_shell_command, search_files, list_directory]
+tools: [read_file, write_file, replace, run_shell_command, search_file_content, list_directory]
 color: green
 ---
 

--- a/agents/gan-planner.md
+++ b/agents/gan-planner.md
@@ -1,7 +1,7 @@
 ---
 name: gan-planner
 description: "GAN Harness — Planner agent. Expands a one-line prompt into a full product specification with features, sprints, evaluation criteria, and design direction."
-tools: [read_file, write_file, search_files, list_directory]
+tools: [read_file, write_file, search_file_content, list_directory]
 color: purple
 ---
 

--- a/agents/harness-optimizer.md
+++ b/agents/harness-optimizer.md
@@ -1,7 +1,7 @@
 ---
 name: harness-optimizer
 description: Analyze and improve the local agent harness configuration for reliability, cost, and throughput.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command", "replace_in_file"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace"]
 color: teal
 ---
 

--- a/agents/healthcare-reviewer.md
+++ b/agents/healthcare-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: healthcare-reviewer
 description: Reviews healthcare application code for clinical safety, CDSS accuracy, PHI compliance, and medical data integrity. Specialized for EMR/EHR, clinical decision support, and health information systems.
-tools: [read_file, search_files, list_directory]
+tools: [read_file, search_file_content, list_directory]
 ---
 
 # Healthcare Reviewer — Clinical Safety & PHI Compliance

--- a/agents/java-build-resolver.md
+++ b/agents/java-build-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: java-build-resolver
 description: Java/Maven/Gradle build, compilation, and dependency error resolution specialist. Fixes build errors, Java compiler errors, and Maven/Gradle issues with minimal changes. Use when Java or Spring Boot builds fail.
-tools: ["read_file", "write_file", "replace_in_file", "run_shell_command", "search_files", "list_directory"]
+tools: ["read_file", "write_file", "replace", "run_shell_command", "search_file_content", "list_directory"]
 ---
 
 # Java Build Error Resolver

--- a/agents/java-reviewer.md
+++ b/agents/java-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: java-reviewer
 description: Expert Java and Spring Boot code reviewer specializing in layered architecture, JPA patterns, security, and concurrency. Use for all Java code changes. MUST BE USED for Spring Boot projects.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command"]
 ---
 You are a senior Java engineer ensuring high standards of idiomatic Java and Spring Boot best practices.
 When invoked:

--- a/agents/kotlin-build-resolver.md
+++ b/agents/kotlin-build-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: kotlin-build-resolver
 description: Kotlin/Gradle build, compilation, and dependency error resolution specialist. Fixes build errors, Kotlin compiler errors, and Gradle issues with minimal changes. Use when Kotlin builds fail.
-tools: ["read_file", "write_file", "replace_in_file", "run_shell_command", "search_files", "list_directory"]
+tools: ["read_file", "write_file", "replace", "run_shell_command", "search_file_content", "list_directory"]
 ---
 
 # Kotlin Build Error Resolver

--- a/agents/kotlin-reviewer.md
+++ b/agents/kotlin-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: kotlin-reviewer
 description: Kotlin and Android/KMP code reviewer. Reviews Kotlin code for idiomatic patterns, coroutine safety, Compose best practices, clean architecture violations, and common Android pitfalls.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command"]
 ---
 
 You are a senior Kotlin and Android/KMP code reviewer ensuring idiomatic, safe, and maintainable code.

--- a/agents/loop-operator.md
+++ b/agents/loop-operator.md
@@ -1,7 +1,7 @@
 ---
 name: loop-operator
 description: Operate autonomous agent loops, monitor progress, and intervene safely when loops stall.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command", "replace_in_file"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace"]
 color: orange
 ---
 

--- a/agents/opensource-forker.md
+++ b/agents/opensource-forker.md
@@ -1,7 +1,7 @@
 ---
 name: opensource-forker
 description: Fork any project for open-sourcing. Copies files, strips secrets and credentials (20+ patterns), replaces internal references with placeholders, generates .env.example, and cleans git history. First stage of the opensource-pipeline skill.
-tools: [read_file, write_file, replace_in_file, run_shell_command, search_files, list_directory]
+tools: [read_file, write_file, replace, run_shell_command, search_file_content, list_directory]
 ---
 
 # Open-Source Forker

--- a/agents/opensource-packager.md
+++ b/agents/opensource-packager.md
@@ -1,7 +1,7 @@
 ---
 name: opensource-packager
 description: Generate complete open-source packaging for a sanitized project. Produces GEMINI.md, setup.sh, README.md, LICENSE, CONTRIBUTING.md, and GitHub issue templates. Makes any repo immediately usable with Gemini CLI. Third stage of the opensource-pipeline skill.
-tools: [read_file, write_file, replace_in_file, run_shell_command, search_files, list_directory]
+tools: [read_file, write_file, replace, run_shell_command, search_file_content, list_directory]
 ---
 
 # Open-Source Packager

--- a/agents/opensource-sanitizer.md
+++ b/agents/opensource-sanitizer.md
@@ -1,7 +1,7 @@
 ---
 name: opensource-sanitizer
 description: Verify an open-source fork is fully sanitized before release. Scans for leaked secrets, PII, internal references, and dangerous files using 20+ regex patterns. Generates a PASS/FAIL/PASS-WITH-WARNINGS report. Second stage of the opensource-pipeline skill. Use PROACTIVELY before any public release.
-tools: [read_file, search_files, list_directory, run_shell_command]
+tools: [read_file, search_file_content, list_directory, run_shell_command]
 ---
 
 # Open-Source Sanitizer

--- a/agents/performance-optimizer.md
+++ b/agents/performance-optimizer.md
@@ -1,7 +1,7 @@
 ---
 name: performance-optimizer
 description: Performance analysis and optimization specialist. Use PROACTIVELY for identifying bottlenecks, optimizing slow code, reducing bundle sizes, and improving runtime performance. Profiling, memory leaks, render optimization, and algorithmic improvements.
-tools: [read_file, write_file, replace_in_file, run_shell_command, search_files, list_directory]
+tools: [read_file, write_file, replace, run_shell_command, search_file_content, list_directory]
 ---
 
 # Performance Optimizer

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use PROACTIVELY when users request feature implementation, architectural changes, or complex refactoring. Automatically activated for planning tasks.
-tools: ["read_file", "search_files", "list_directory"]
+tools: ["read_file", "search_file_content", "list_directory"]
 ---
 
 You are an expert planning specialist focused on creating comprehensive, actionable implementation plans.

--- a/agents/pr-test-analyzer.md
+++ b/agents/pr-test-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-test-analyzer
 description: Review pull request test coverage quality and completeness, with emphasis on behavioral coverage and real bug prevention.
-tools: [read_file, search_files, list_directory, run_shell_command]
+tools: [read_file, search_file_content, list_directory, run_shell_command]
 ---
 
 # PR Test Analyzer Agent

--- a/agents/pytorch-build-resolver.md
+++ b/agents/pytorch-build-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: pytorch-build-resolver
 description: PyTorch runtime, CUDA, and training error resolution specialist. Fixes tensor shape mismatches, device errors, gradient issues, DataLoader problems, and mixed precision failures with minimal changes. Use when PyTorch training or inference crashes.
-tools: ["read_file", "write_file", "replace_in_file", "run_shell_command", "search_files", "list_directory"]
+tools: ["read_file", "write_file", "replace", "run_shell_command", "search_file_content", "list_directory"]
 ---
 
 # PyTorch Build/Runtime Error Resolver

--- a/agents/rust-build-resolver.md
+++ b/agents/rust-build-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: rust-build-resolver
 description: Rust build, compilation, and dependency error resolution specialist. Fixes cargo build errors, borrow checker issues, and Cargo.toml problems with minimal changes. Use when Rust builds fail.
-tools: ["read_file", "write_file", "replace_in_file", "run_shell_command", "search_files", "list_directory"]
+tools: ["read_file", "write_file", "replace", "run_shell_command", "search_file_content", "list_directory"]
 ---
 
 # Rust Build Error Resolver

--- a/agents/rust-reviewer.md
+++ b/agents/rust-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: rust-reviewer
 description: Expert Rust code reviewer specializing in ownership, lifetimes, error handling, unsafe usage, and idiomatic patterns. Use for all Rust code changes. MUST BE USED for Rust projects.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command"]
 ---
 
 You are a senior Rust code reviewer ensuring high standards of safety, idiomatic patterns, and performance.

--- a/agents/seo-specialist.md
+++ b/agents/seo-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: seo-specialist
 description: SEO specialist for technical SEO audits, on-page optimization, structured data, Core Web Vitals, and content/keyword mapping. Use for site audits, meta tag reviews, schema markup, sitemap and robots issues, and SEO remediation plans.
-tools: [read_file, search_files, list_directory, run_shell_command, google_web_search]
+tools: [read_file, search_file_content, list_directory, run_shell_command, google_web_search]
 ---
 
 You are a senior SEO specialist focused on technical SEO, search visibility, and sustainable ranking improvements.

--- a/agents/silent-failure-hunter.md
+++ b/agents/silent-failure-hunter.md
@@ -1,7 +1,7 @@
 ---
 name: silent-failure-hunter
 description: Review code for silent failures, swallowed errors, bad fallbacks, and missing error propagation.
-tools: [read_file, search_files, list_directory, run_shell_command]
+tools: [read_file, search_file_content, list_directory, run_shell_command]
 ---
 
 # Silent Failure Hunter Agent

--- a/agents/type-design-analyzer.md
+++ b/agents/type-design-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: type-design-analyzer
 description: Analyze type design for encapsulation, invariant expression, usefulness, and enforcement.
-tools: [read_file, search_files, list_directory, run_shell_command]
+tools: [read_file, search_file_content, list_directory, run_shell_command]
 ---
 
 # Type Design Analyzer Agent

--- a/agents/typescript-reviewer.md
+++ b/agents/typescript-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: typescript-reviewer
 description: Expert TypeScript/JavaScript code reviewer specializing in type safety, async correctness, Node/web security, and idiomatic patterns. Use for all TypeScript and JavaScript code changes. MUST BE USED for TypeScript/JavaScript projects.
-tools: ["read_file", "search_files", "list_directory", "run_shell_command"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command"]
 ---
 
 You are a senior TypeScript engineer ensuring high standards of type-safe, idiomatic TypeScript and JavaScript.

--- a/docs/en/agents/README.md
+++ b/docs/en/agents/README.md
@@ -103,8 +103,8 @@ Agents in Everything Gemini Code use Gemini CLI tool names:
 |------|-------------|
 | `read_file` | Read file contents |
 | `write_file` | Write to files |
-| `replace_in_file` | Edit file content |
+| `replace` | Edit file content |
 | `run_shell_command` | Execute shell commands |
-| `search_files` | Search/grep in files |
+| `search_file_content` | Search/grep in files |
 | `list_directory` | List directory contents |
 | `google_web_search` | Web search |

--- a/docs/en/contributing/SKILL-PLACEMENT-POLICY.md
+++ b/docs/en/contributing/SKILL-PLACEMENT-POLICY.md
@@ -80,7 +80,7 @@ Note: If you adapt skill references from Claude Code, be aware that tool names d
 |-------------|------------|
 | `Read` | `read_file` |
 | `Write` | `write_file` |
-| `Edit` | `replace_in_file` |
+| `Edit` | `replace` |
 | `Bash` | `run_shell_command` |
-| `Grep` | `search_files` |
+| `Grep` | `search_file_content` |
 | `Glob` | `list_directory` |

--- a/docs/en/contributing/TERMINOLOGY.md
+++ b/docs/en/contributing/TERMINOLOGY.md
@@ -55,9 +55,9 @@ Gemini CLI and Claude Code use different tool names:
 |-------------|------------|
 | `Read` | `read_file` |
 | `Write` | `write_file` |
-| `Edit` | `replace_in_file` |
+| `Edit` | `replace` |
 | `Bash` | `run_shell_command` |
-| `Grep` | `search_files` |
+| `Grep` | `search_file_content` |
 | `Glob` | `list_directory` |
 | `WebSearch` | `google_web_search` |
 

--- a/docs/ko-KR/contributing/README.md
+++ b/docs/ko-KR/contributing/README.md
@@ -108,9 +108,9 @@ Claude Code 에이전트를 변환하는 경우:
 |-------------|------------|
 | `Read` | `read_file` |
 | `Write` | `write_file` |
-| `Edit` | `replace_in_file` |
+| `Edit` | `replace` |
 | `Bash` | `run_shell_command` |
-| `Grep` | `search_files` |
+| `Grep` | `search_file_content` |
 | `Glob` | `list_directory` |
 | `WebSearch` | `google_web_search` |
 

--- a/docs/ko-KR/contributing/SKILL-PLACEMENT-POLICY.md
+++ b/docs/ko-KR/contributing/SKILL-PLACEMENT-POLICY.md
@@ -82,7 +82,7 @@ Claude Code에서 스킬 참조를 변환할 때 도구 이름이 다릅니다:
 |-------------|------------|
 | `Read` | `read_file` |
 | `Write` | `write_file` |
-| `Edit` | `replace_in_file` |
+| `Edit` | `replace` |
 | `Bash` | `run_shell_command` |
-| `Grep` | `search_files` |
+| `Grep` | `search_file_content` |
 | `Glob` | `list_directory` |

--- a/docs/ko-KR/contributing/TERMINOLOGY.md
+++ b/docs/ko-KR/contributing/TERMINOLOGY.md
@@ -57,9 +57,9 @@ Gemini CLI와 Claude Code는 도구 이름이 다릅니다:
 |-------------|------------|
 | `Read` | `read_file` |
 | `Write` | `write_file` |
-| `Edit` | `replace_in_file` |
+| `Edit` | `replace` |
 | `Bash` | `run_shell_command` |
-| `Grep` | `search_files` |
+| `Grep` | `search_file_content` |
 | `Glob` | `list_directory` |
 
 ---

--- a/docs/ko-KR/contributing/TERMINOLOGY.md
+++ b/docs/ko-KR/contributing/TERMINOLOGY.md
@@ -61,6 +61,7 @@ Gemini CLI와 Claude Code는 도구 이름이 다릅니다:
 | `Bash` | `run_shell_command` |
 | `Grep` | `search_file_content` |
 | `Glob` | `list_directory` |
+| `WebSearch` | `google_web_search` |
 
 ---
 


### PR DESCRIPTION
Replace `search_files` with `search_file_content` and `replace_in_file` with `replace` across all agent frontmatter and documentation. These were not valid Gemini CLI built-in tool names and caused agent loading failures at startup (validation error: `tools.N: Invalid tool name`).

The terminology tables in docs/ that mapped Claude Code tools to Gemini CLI equivalents were the source of the incorrect names, which had propagated into 18 agent files.

Fixes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository-wide configuration for automated, incremental code reviews with an assertive, bug/security-first tone; enabled early-access/free-tier behavior, chat auto-replies, labeling rules, path filters, and security/style checks (shellcheck, gitleaks, markdownlint, eslint).
  * Standardized internal tool names and capabilities across agent configurations for consistent behavior.

* **Documentation**
  * Updated contributor and agent docs and mapping tables to reflect the new tool name mappings and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->