### PR TITLE
fix: remove invalid MCP tool refs and color frontmatter from agents

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,10 +37,11 @@ reviews:
   path_instructions:
     - path: "agents/**/*.md"
       instructions: |
-        Gemini CLI agent definitions. The YAML frontmatter `tools:` array may
-        ONLY contain valid Gemini CLI built-in tools: read_file, read_many_files,
-        write_file, replace, glob, search_file_content, list_directory,
-        run_shell_command, save_memory, web_fetch, google_web_search.
+        Gemini CLI agent definitions. YAML frontmatter MUST include `name`,
+        `description`, and `tools`. The `tools:` array may ONLY contain valid
+        Gemini CLI built-in tools: read_file, read_many_files, write_file,
+        replace, glob, search_file_content, list_directory, run_shell_command,
+        save_memory, web_fetch, google_web_search.
 
         Reject:
           - Claude-style names: `search_files`, `replace_in_file`, `Read`, `Edit`.
@@ -49,9 +50,11 @@ reviews:
             load time. MCP tools are auto-discovered from the configured MCP
             server at runtime and must NOT be declared in agent frontmatter.
             Agent body text describing MCP tool usage is fine and expected.
+          - Frontmatter keys outside the Gemini CLI schema (e.g. `color`,
+            `model`).
 
-        Reject frontmatter keys outside the Gemini CLI schema (e.g. `color`,
-        `model`). Each agent must have `name` and `description` in frontmatter.
+        The authoritative tool allowlist is also documented in
+        `.gemini/styleguide.md` — keep the two in sync.
     - path: "commands/**/*.toml"
       instructions: |
         Gemini CLI command definitions in TOML format. Verify command metadata

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,17 +37,21 @@ reviews:
   path_instructions:
     - path: "agents/**/*.md"
       instructions: |
-        Gemini CLI agent definitions. The YAML frontmatter `tools:` array must
-        contain either:
-          (a) a valid Gemini CLI built-in tool: read_file, read_many_files,
-              write_file, replace, glob, search_file_content, list_directory,
-              run_shell_command, save_memory, web_fetch, google_web_search; or
-          (b) an MCP tool in the form `mcp__<server>__<tool_name>`.
-        Reject Claude-style names like `search_files`, `replace_in_file`, `Read`,
-        `Edit`. Also flag when the agent body references MCP tools (e.g. Slack,
-        Context7) that are not declared in the frontmatter `tools:` array — the
-        agent will be unable to call them at runtime. Each agent must have `name`
-        and `description` in frontmatter.
+        Gemini CLI agent definitions. The YAML frontmatter `tools:` array may
+        ONLY contain valid Gemini CLI built-in tools: read_file, read_many_files,
+        write_file, replace, glob, search_file_content, list_directory,
+        run_shell_command, save_memory, web_fetch, google_web_search.
+
+        Reject:
+          - Claude-style names: `search_files`, `replace_in_file`, `Read`, `Edit`.
+          - MCP tool references (e.g. `mcp__slack__...`, `mcp__context7__...`).
+            Gemini CLI's agent schema rejects these with "Invalid tool name" at
+            load time. MCP tools are auto-discovered from the configured MCP
+            server at runtime and must NOT be declared in agent frontmatter.
+            Agent body text describing MCP tool usage is fine and expected.
+
+        Reject frontmatter keys outside the Gemini CLI schema (e.g. `color`,
+        `model`). Each agent must have `name` and `description` in frontmatter.
     - path: "commands/**/*.toml"
       instructions: |
         Gemini CLI command definitions in TOML format. Verify command metadata

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -42,9 +42,17 @@ The codebase consists of:
 
 ## Markdown Agents
 
-- Must have YAML frontmatter with `tools` field.
-- Tool names must use Gemini format: `read_file`, `run_shell_command`, `write_file`.
-- No `model` field (Gemini CLI does not support it).
+- Must have YAML frontmatter with `name`, `description`, and `tools` fields.
+- `tools` entries must be valid Gemini CLI built-ins only: `read_file`,
+  `read_many_files`, `write_file`, `replace`, `glob`, `search_file_content`,
+  `list_directory`, `run_shell_command`, `save_memory`, `web_fetch`,
+  `google_web_search`.
+- Do NOT include MCP tools (e.g. `mcp__slack__...`, `mcp__context7__...`) in
+  the `tools` array — Gemini CLI rejects them at load time. MCP tools are
+  auto-discovered from the configured MCP server at runtime.
+- Do NOT include Claude-style names (`search_files`, `replace_in_file`,
+  `Read`, `Edit`) — those are not valid in Gemini CLI.
+- No `model` or `color` field (Gemini CLI schema does not support them).
 
 ## Documentation
 

--- a/agents/chief-of-staff.md
+++ b/agents/chief-of-staff.md
@@ -1,7 +1,7 @@
 ---
 name: chief-of-staff
 description: Personal communication chief of staff that triages email, Slack, LINE, and Messenger. Classifies messages into 4 tiers (skip/info_only/meeting_info/action_required), generates draft replies, and enforces post-send follow-through via hooks. Use when managing multi-channel communication workflows.
-tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace", "write_file", "mcp__slack__conversations_search_messages", "mcp__slack__channels_list", "mcp__slack__conversations_history", "mcp__slack__conversations_add_message"]
+tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace", "write_file"]
 ---
 
 You are a personal chief of staff that manages all communication channels — email, Slack, LINE, Messenger, and calendar — through a unified triage pipeline.

--- a/agents/docs-lookup.md
+++ b/agents/docs-lookup.md
@@ -1,7 +1,7 @@
 ---
 name: docs-lookup
 description: When the user asks how to use a library, framework, or API or needs up-to-date code examples, use Context7 MCP to fetch current documentation and return answers with examples. Invoke for docs/API/setup questions.
-tools: ["read_file", "search_file_content", "mcp__context7__resolve-library-id", "mcp__context7__query-docs"]
+tools: ["read_file", "search_file_content"]
 ---
 
 You are a documentation specialist. You answer questions about libraries, frameworks, and APIs using current documentation fetched via the Context7 MCP (resolve-library-id and query-docs), not training data.

--- a/agents/gan-evaluator.md
+++ b/agents/gan-evaluator.md
@@ -2,7 +2,6 @@
 name: gan-evaluator
 description: "GAN Harness — Evaluator agent. Tests the live running application via Playwright, scores against rubric, and provides actionable feedback to the Generator."
 tools: [read_file, write_file, run_shell_command, search_file_content, list_directory]
-color: red
 ---
 
 You are the **Evaluator** in a GAN-style multi-agent harness (inspired by Anthropic's harness design paper, March 2026).

--- a/agents/gan-generator.md
+++ b/agents/gan-generator.md
@@ -2,7 +2,6 @@
 name: gan-generator
 description: "GAN Harness — Generator agent. Implements features according to the spec, reads evaluator feedback, and iterates until quality threshold is met."
 tools: [read_file, write_file, replace, run_shell_command, search_file_content, list_directory]
-color: green
 ---
 
 You are the **Generator** in a GAN-style multi-agent harness (inspired by Anthropic's harness design paper, March 2026).

--- a/agents/gan-planner.md
+++ b/agents/gan-planner.md
@@ -2,7 +2,6 @@
 name: gan-planner
 description: "GAN Harness — Planner agent. Expands a one-line prompt into a full product specification with features, sprints, evaluation criteria, and design direction."
 tools: [read_file, write_file, search_file_content, list_directory]
-color: purple
 ---
 
 You are the **Planner** in a GAN-style multi-agent harness (inspired by Anthropic's harness design paper, March 2026).

--- a/agents/harness-optimizer.md
+++ b/agents/harness-optimizer.md
@@ -2,7 +2,6 @@
 name: harness-optimizer
 description: Analyze and improve the local agent harness configuration for reliability, cost, and throughput.
 tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace"]
-color: teal
 ---
 
 You are the harness optimizer.

--- a/agents/loop-operator.md
+++ b/agents/loop-operator.md
@@ -2,7 +2,6 @@
 name: loop-operator
 description: Operate autonomous agent loops, monitor progress, and intervene safely when loops stall.
 tools: ["read_file", "search_file_content", "list_directory", "run_shell_command", "replace"]
-color: orange
 ---
 
 You are the loop operator.


### PR DESCRIPTION
Gemini CLI's agent schema rejects two patterns that were producing "Validation failed" errors at extension install / session start:

1. `mcp__<server>__<tool>` entries in the frontmatter `tools:` array — the schema only accepts built-in tool names. MCP tools stay usable at runtime via the configured MCP server regardless of being listed; removing them from the array just unblocks validation. Fixed in chief-of-staff.md (4 Slack entries) and docs-lookup.md (2 Context7 entries); the agent bodies still document how to invoke them.

2. `color:` key in frontmatter — not part of the Gemini CLI agent schema (appears to be a Claude Code carry-over). Removed from gan-evaluator, gan-generator, gan-planner, harness-optimizer, and loop-operator.

Note: the previously observed `~/.gemini/commands/command-explain.toml` parse error is from a user-local file outside this repo and is not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed messaging and external doc lookup integrations from several agents; retained local file and system utilities.
  * Cleared non-functional visual metadata (color fields) from multiple agents for UI/validation consistency.

* **Chores**
  * Tightened agent frontmatter validation to restrict declared tools to the allowlist and disallow unsupported metadata keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->