### PR TITLE
docs: note Antigravity-only bare workflow names vs Gemini CLI egc- pr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ Use custom commands to automate workflows (see [Full Command List](docs/en/comma
 /egc-code-review
 ```
 
+> **Antigravity users:** workflows are installed under bare names
+> (e.g. `/tdd`, `/code-review`, `/build-fix`) — the `egc-` prefix is only
+> applied to `/egc-plan`, which would otherwise conflict with Antigravity's
+> built-in `/plan`. In Gemini CLI every command uses the `egc-` prefix to
+> avoid collisions with its built-in command set.
+
 ### Agents
 
 Delegate complex tasks to specialized agents:

--- a/docs/ko-KR/README.md
+++ b/docs/ko-KR/README.md
@@ -70,6 +70,11 @@ Antigravity 사용자는 스크립트를 사용하세요:
 @security-reviewer "이 파일의 인젝션 취약점 감사"
 ```
 
+> **Antigravity 사용자 참고:** 워크플로우는 bare name 으로 설치됩니다
+> (예: `/tdd`, `/code-review`, `/build-fix`). Antigravity 내장 `/plan` 과
+> 충돌하는 `/egc-plan` 에만 `egc-` 프리픽스가 붙습니다. Gemini CLI 에서는
+> 내장 커맨드 충돌 방지를 위해 모든 커맨드가 `egc-` 프리픽스를 사용합니다.
+
 ✨ **완료!** 이제 28개 에이전트, 125개 스킬, 60개 커맨드를 사용할 수 있습니다.
 
 ---

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -78,6 +78,11 @@ gemini extensions uninstall https://github.com/Jamkris/everything-gemini-code
 /egc-code-review
 ```
 
+> **Antigravity 用户注意：** 工作流使用裸名称安装
+> （例如 `/tdd`、`/code-review`、`/build-fix`）。只有与 Antigravity 内置
+> `/plan` 冲突的 `/egc-plan` 会加上 `egc-` 前缀。在 Gemini CLI 中，所有命令
+> 都使用 `egc-` 前缀以避免与内置命令集冲突。
+
 ### 智能体 (Agents)
 
 将复杂任务委托给专用智能体：


### PR DESCRIPTION
…efix

Only `/egc-plan` gets the `egc-` prefix under Antigravity (it would otherwise shadow Antigravity's built-in `/plan`). Every other workflow installed via `scripts/install.sh --antigravity` keeps its bare name (`/tdd`, `/build-fix`, `/code-review`, …). Gemini CLI still requires the prefix on every command to avoid its built-in command collisions.

Add this note to the Slash Commands section of the EN/KO/ZH READMEs so users don't assume commands were renamed everywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on command naming conventions for Antigravity workflows, explaining that workflows use bare command names (e.g., `/tdd`, `/code-review`, `/build-fix`) with the exception of `/egc-plan` to avoid conflicts with built-in commands.
  * Updated documentation in English, Korean, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->