### PR TITLE
chore: add Greptile and GitGuardian configs

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -27,9 +27,10 @@ secret:
     - 'tests/lint/fixtures/**'
     - 'tests/ci/**'
 
-  # Reduce noise from broad detectors that misfire on documentation
-  # examples (curl snippets, example tokens like "sk-proj-xxxxx").
-  ignored_detectors:
-    - 'Generic High Entropy Secret'
+    # Documentation examples that show fake secret literals (e.g. the
+    # `sk-proj-xxxxx` placeholder in rules/typescript/security.md). These
+    # are illustrative and never match a real key.
+    - 'rules/**/security.md'
+    - '**/SKILL.md'
 
   show_secrets: false

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,35 @@
+version: 2
+
+# Public OSS repo on the GitGuardian Free tier. Defaults are fine for most
+# of the tree; we only add path-level excludes for noise (lockfiles, vendored
+# binary assets) and intentional dummy values used in security-hook tests.
+
+exit_zero: false
+verbose: false
+
+secret:
+  ignored_paths:
+    # Lockfiles and machine-generated artifacts
+    - 'package-lock.json'
+    - '**/package-lock.json'
+    - 'node_modules/**'
+    - '*.lock'
+    - '.DS_Store'
+
+    # Binary/static assets that scanners shouldn't probe
+    - 'docs/**/*.png'
+    - 'docs/**/*.jpg'
+
+    # Test fixtures: tests/lint/fixtures/agents/* contains intentionally
+    # malformed YAML and tests/ci/* embeds GitHub Actions expression
+    # strings (`${{ github.event.pull_request.head.sha }}`) — neither is
+    # a real secret but pattern-matchers can flag the latter.
+    - 'tests/lint/fixtures/**'
+    - 'tests/ci/**'
+
+  # Reduce noise from broad detectors that misfire on documentation
+  # examples (curl snippets, example tokens like "sk-proj-xxxxx").
+  ignored_detectors:
+    - 'Generic High Entropy Secret'
+
+  show_secrets: false

--- a/greptile.json
+++ b/greptile.json
@@ -5,10 +5,22 @@
 	"triggerOnUpdates": true,
 	"triggerOnDrafts": false,
 	"shouldUpdateDescription": false,
-	"summarySection": true,
-	"confidenceScoreSection": true,
-	"sequenceDiagramSection": false,
-	"ignoreKeywords": "bump version\nrelease\nchore: bump\nchore(release)\nchore(deps)",
+	"summarySection": {
+		"included": true,
+		"collapsible": false,
+		"defaultOpen": true
+	},
+	"confidenceScoreSection": {
+		"included": true,
+		"collapsible": false,
+		"defaultOpen": true
+	},
+	"sequenceDiagramSection": {
+		"included": false,
+		"collapsible": false,
+		"defaultOpen": false
+	},
+	"ignoreKeywords": "bump version\nchore: bump\nchore: release\nchore(release)\nchore(deps)",
 	"ignorePatterns": "node_modules/**\npackage-lock.json\n*.lock\n.DS_Store\nassets/**\ndocs/**/*.png\ndocs/**/*.jpg",
 	"disabledLabels": ["release", "skip-review"],
 	"instructions": "This is a Gemini CLI extension (everything-gemini-code) — not a typical application. Codebase consists of: shell/Node scripts (scripts/), TOML commands (commands/), Markdown skills (skills/) and agents (agents/), JSON hooks (hooks/), and multilingual docs (docs/{en,ko-KR,zh-CN}). Be concise and direct. Prioritize bugs and security issues over style. Do NOT flag emoji usage in markdown, long TOML prompt fields, or skills referencing ~/.gemini/ paths.",
@@ -27,15 +39,15 @@
 				"scope": ["skills/**/*.md"]
 			},
 			{
-				"rule": "Hook scripts and hooks.json. Hooks run automatically on Gemini CLI tool events (BeforeTool, AfterTool, SessionStart, SessionEnd, PreCompress, AfterAgent) — any failure impacts every session. Verify error handling, quiet logging, and intentional exit codes (0 = allow, 2 = block in BeforeTool).",
+				"rule": "Hook scripts and hooks.json. Hooks run automatically on Gemini CLI tool events (BeforeTool, AfterTool, SessionStart, SessionEnd, PreCompress, AfterAgent) — any failure impacts every session. Verify error handling, intentional exit codes (0 = allow, 2 = block in BeforeTool), and that the script runs silently on success: NO console.log in hook scripts, only stderr writes for blocking diagnostics.",
 				"scope": ["hooks/**", "scripts/hooks/**"]
 			},
 			{
-				"rule": "Shell scripts must use `set -euo pipefail`, quote all variables, and avoid interpolating shell variables into `node -e` strings (use process.env instead). Support both macOS and Linux — no GNU-only flags.",
+				"rule": "Shell scripts must use `set -e` at the top (per .gemini/styleguide.md), quote all variables, and avoid interpolating shell variables into `node -e` strings (use process.env instead). Support both macOS and Linux — no GNU-only flags.",
 				"scope": ["scripts/**/*.sh", "**/*.sh"]
 			},
 			{
-				"rule": "Node.js 20+ project. Avoid mutation — prefer spread/immutable patterns. Handle errors explicitly; never swallow silently. Functions should be under 50 lines (soft target — vendored upstream ports may exceed). No console.log in hook scripts (hooks must run silently on success).",
+				"rule": "Node.js 20+ project. Avoid mutation — prefer spread/immutable patterns. Handle errors explicitly; never swallow silently. Functions should be under 50 lines (soft target — vendored upstream ports may exceed). console.log is fine in scripts and tests (the no-console rule lives on the hooks rule above).",
 				"scope": ["scripts/**/*.js", "tests/**/*.js"]
 			},
 			{

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,63 @@
+{
+	"$schema": "https://www.greptile.com/schemas/greptile.json",
+	"strictness": 2,
+	"commentTypes": ["logic", "syntax"],
+	"triggerOnUpdates": true,
+	"triggerOnDrafts": false,
+	"shouldUpdateDescription": false,
+	"summarySection": true,
+	"confidenceScoreSection": true,
+	"sequenceDiagramSection": false,
+	"ignoreKeywords": "bump version\nrelease\nchore: bump\nchore(release)\nchore(deps)",
+	"ignorePatterns": "node_modules/**\npackage-lock.json\n*.lock\n.DS_Store\nassets/**\ndocs/**/*.png\ndocs/**/*.jpg",
+	"disabledLabels": ["release", "skip-review"],
+	"instructions": "This is a Gemini CLI extension (everything-gemini-code) — not a typical application. Codebase consists of: shell/Node scripts (scripts/), TOML commands (commands/), Markdown skills (skills/) and agents (agents/), JSON hooks (hooks/), and multilingual docs (docs/{en,ko-KR,zh-CN}). Be concise and direct. Prioritize bugs and security issues over style. Do NOT flag emoji usage in markdown, long TOML prompt fields, or skills referencing ~/.gemini/ paths.",
+	"customContext": {
+		"rules": [
+			{
+				"rule": "Gemini CLI agent definitions. YAML frontmatter MUST include `name`, `description`, and `tools`. The `tools:` array may ONLY contain valid Gemini CLI built-in tools: read_file, read_many_files, write_file, replace, glob, search_file_content, list_directory, run_shell_command, save_memory, web_fetch, google_web_search. Reject Claude-style names (search_files, replace_in_file, Read, Edit), MCP tool references (mcp__*) — those are auto-discovered at runtime and rejected by the schema if declared. Reject frontmatter keys outside the schema (color, model). Authoritative allowlist lives in scripts/lib/gemini-tools.js.",
+				"scope": ["agents/**/*.md"]
+			},
+			{
+				"rule": "Gemini CLI command definitions in TOML. Filename MUST start with the `egc-` prefix (avoids collision with built-in /plan, /docs). `description` must be non-empty.",
+				"scope": ["commands/**/*.toml"]
+			},
+			{
+				"rule": "Skill definitions. Frontmatter must include `name` and `description`. The body must contain a `## When to Use` section with specific, actionable trigger conditions — not `When to Activate` or `When to Apply`.",
+				"scope": ["skills/**/*.md"]
+			},
+			{
+				"rule": "Hook scripts and hooks.json. Hooks run automatically on Gemini CLI tool events (BeforeTool, AfterTool, SessionStart, SessionEnd, PreCompress, AfterAgent) — any failure impacts every session. Verify error handling, quiet logging, and intentional exit codes (0 = allow, 2 = block in BeforeTool).",
+				"scope": ["hooks/**", "scripts/hooks/**"]
+			},
+			{
+				"rule": "Shell scripts must use `set -euo pipefail`, quote all variables, and avoid interpolating shell variables into `node -e` strings (use process.env instead). Support both macOS and Linux — no GNU-only flags.",
+				"scope": ["scripts/**/*.sh", "**/*.sh"]
+			},
+			{
+				"rule": "Node.js 20+ project. Avoid mutation — prefer spread/immutable patterns. Handle errors explicitly; never swallow silently. Functions should be under 50 lines (soft target — vendored upstream ports may exceed). No console.log in hook scripts (hooks must run silently on success).",
+				"scope": ["scripts/**/*.js", "tests/**/*.js"]
+			},
+			{
+				"rule": "Coding rules shipped to end users at ~/.gemini/rules/. Cross-references between common/ and language-specific files must use relative paths (../common/xxx.md) and the targets must exist.",
+				"scope": ["rules/**/*.md"]
+			},
+			{
+				"rule": "User-facing multilingual documentation. Tool-name mapping tables (Claude Code ↔ Gemini CLI) must list ONLY valid Gemini CLI tool names — incorrect mappings here propagate into agent/skill definitions.",
+				"scope": ["docs/**/*.md"]
+			}
+		],
+		"files": [
+			{
+				"path": ".gemini/styleguide.md",
+				"description": "Project conventions for shell scripts, TOML commands, agents, skills, hooks, and CI workflows.",
+				"scope": ["**"]
+			},
+			{
+				"path": "scripts/lib/gemini-tools.js",
+				"description": "Authoritative source of valid Gemini CLI agent tool names and forbidden frontmatter keys.",
+				"scope": ["agents/**", "scripts/ci/validate-agents.js"]
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

Adds in-repo configuration for two of the three review/security bots in active use on the upstream `everything-claude-code`. All three are free for our case (MIT-licensed public repo).

| Tool | Free for us? | In-repo config? |
|---|---|---|
| Greptile | ✅ via the [OSS Perks program](https://www.ossperks.com/programs/greptile) (MIT/Apache/GPL) | `greptile.json` (this PR) |
| GitGuardian | ✅ public-repo free tier | `.gitguardian.yaml` (this PR) |
| Cubic | ✅ unlimited for public repos | None — GitHub App only |

## `greptile.json`

Mirrors the intent of `.coderabbit.yaml`:

- `strictness: 2` + `commentTypes: [logic, syntax]` — bugs and security over style
- `ignoreKeywords` — release PRs and dependabot PRs are skipped
- `disabledLabels: ["release", "skip-review"]` — manual escape hatch
- `instructions` — project base prompt that frames the repo as a Gemini CLI extension and lists the common false-positive patterns to ignore (emoji in markdown, long TOML prompt fields, `~/.gemini/` paths in skills)
- `customContext.rules` — per-path guidance for `agents/`, `commands/`, `skills/`, `hooks/`, `scripts/`, `rules/`, `docs/` (mirrors `path_instructions` from CodeRabbit, including the agent tool allowlist)
- `customContext.files` — pins `.gemini/styleguide.md` and `scripts/lib/gemini-tools.js` as the authoritative references the bot should consult

## `.gitguardian.yaml`

Defaults are fine for most of the tree; this just suppresses noise:

- `secret.ignored_paths` — lockfiles, `node_modules`, binary doc assets, plus `tests/lint/fixtures/**` and `tests/ci/**` (the latter embeds intentional hostile-workflow fixtures with `${{ github.event.pull_request.head.sha }}` strings that some entropy detectors misfire on)
- `ignored_detectors: ['Generic High Entropy Secret']` — kills the most common false positive, documentation/curl examples

## Cubic

No in-repo file. Custom rules are configured in their dashboard, optionally synced from `.cursor/rules/` if the team uses those (we don't). Just need to install the app on the repo.

## Action items for the maintainer

Out of scope of a code change — these need account/dashboard work:

- [ ] Install the Cubic GitHub App: https://github.com/apps/cubic-dev-ai
- [ ] Apply for the Greptile OSS plan via OSS Perks (https://www.ossperks.com/programs/greptile) — required for free tier; otherwise the trial expires and `greptile.json` becomes dead config
- [ ] GitGuardian should already pick up `.gitguardian.yaml` automatically once the org is on the free OSS tier — if not yet installed, install via dashboard

## Test plan

- [x] `node -e "JSON.parse(...)"` parses `greptile.json`
- [x] `js-yaml` parses `.gitguardian.yaml` (v2 schema)
- [x] `npm run lint` — clean
- [x] `npm test` — 187/187 pass (no behavior change)
- [ ] After merge, watch the next non-release PR to verify Greptile picks up the config (instructions visible in walkthrough, dependabot/release titles correctly skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated secret scanning to detect and prevent sensitive credentials and information from entering the repository, with customized detection patterns and exclusions for various file types, dependencies, and directories.
  * Added comprehensive code quality and governance configuration with specific rules, guidelines, and standards to enforce best practices and consistency throughout the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add in-repo configs for Greptile (code review) and GitGuardian (secret scanning) on OSS free tiers. Tightens review focus on bugs/security and reduces noise without hiding real issues.

- **New Features**
  - `greptile.json`: `strictness: 2` with `commentTypes: [logic, syntax]`; precise skip rules via `ignoreKeywords` (e.g., `chore: release`, dependabot) and `disabledLabels: ["release", "skip-review"]`; section fields use objects; ignores lockfiles/assets. Adds project instructions, per-path rules, and pins `.gemini/styleguide.md` and `scripts/lib/gemini-tools.js` as references. Rule fixes: hooks-only “no console.log”; shell scripts require `set -e` (aligned with the styleguide).
  - `.gitguardian.yaml`: keeps detectors enabled; uses path-scoped ignores for known false positives (`rules/**/security.md`, `**/SKILL.md`) and suppresses noise from lockfiles, `node_modules`, binary docs, and test fixtures. Fails on real findings.

- **Migration**
  - Apply for the Greptile OSS plan so the config is active.
  - Ensure the GitGuardian app is installed; it will auto-load `.gitguardian.yaml`.

<sup>Written for commit e97b09c953f7142953f4a612e982bc409ef5b52d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

