### PR TITLE
chore: release v1.3.6

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v1.3.6 release. Updated version fields in package.json, .gemini-plugin/plugin.json, and gemini-extension.json; no functional changes.

<sup>Written for commit 65a4df5313f2a97c3999a8256b39aaa99f487806. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

