### PR TITLE
docs: update SECURITY.md contact + supported versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,13 @@
 
 ## Supported Versions
 
+Only the latest minor release line receives security fixes. Older lines are not patched —
+upgrade to the current `1.3.x` release.
+
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.2.x   | :white_check_mark: |
-| 1.1.x   | :white_check_mark: |
-| < 1.1   | :x:                |
+| 1.3.x   | :white_check_mark: |
+| < 1.3   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -14,7 +16,9 @@ If you discover a security vulnerability in Everything Gemini Code, please repor
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, email **<security@egc.tools>** with:
+Preferred channel: open a [GitHub private security advisory](https://github.com/Jamkris/everything-gemini-code/security/advisories/new).
+
+Alternatively, email **<contact@jamkris.com>** with:
 
 - A description of the vulnerability
 - Steps to reproduce


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update SECURITY.md to make 1.3.x the only supported release line and clarify that only the latest minor gets security fixes. Set GitHub private security advisories as the preferred reporting channel, with contact@jamkris.com as the fallback email.

<sup>Written for commit 96865175a99bd5d74828af7e05e7e2decdfbd955. Summary will update on new commits. <a href="https://cubic.dev/pr/Jamkris/everything-gemini-code/pull/53?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

