### PR TITLE
chore: release v1.3.7

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `everything-gemini-code` version to 1.3.7 in `.gemini-plugin/plugin.json`, `gemini-extension.json`, and `package.json` to prepare the v1.3.7 release. No code changes.

<sup>Written for commit 7fa868c4269edf28cc03e1105f4dc1bf7555c904. Summary will update on new commits. <a href="https://cubic.dev/pr/Jamkris/everything-gemini-code/pull/55?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

