### PR TITLE
chore: release v1.3.8

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped version to 1.3.8 to publish the next patch release. Updated `package.json`, `.gemini-plugin/plugin.json`, and `gemini-extension.json` to keep versions in sync; no code changes.

<sup>Written for commit a899a9cad7aabc1d6358cde14feef13baa446750. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

