### PR TITLE
chore: refuse release.sh from main; require release branch

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,6 +17,25 @@ fi
 # Remove 'v' prefix if provided
 VERSION="${VERSION#v}"
 
+# Refuse to run on main. The release workflow expects the version
+# bump to land via a reviewable PR — committing directly to main
+# bypasses CI, code review, and the merge audit trail. If you really
+# need to release from main (genuine emergency), comment out this
+# guard temporarily; do not add an env-var escape hatch because that
+# normalises the wrong path.
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" = "main" ]; then
+    echo "Error: refusing to run release from 'main' branch." >&2
+    echo "" >&2
+    echo "Version bumps must go through a PR:" >&2
+    echo "  1. git checkout -b chore/release-v$VERSION" >&2
+    echo "  2. ./scripts/release.sh $VERSION   # re-run on the release branch" >&2
+    echo "  3. git push -u origin chore/release-v$VERSION" >&2
+    echo "  4. gh pr create --title \"chore: release v$VERSION\" --body \"Bump version to $VERSION\"" >&2
+    echo "  5. Merge once CI is green, then push the tag." >&2
+    exit 1
+fi
+
 echo "Preparing release v$VERSION..."
 
 # 1. Update package.json
@@ -42,17 +61,9 @@ git commit -m "chore: bump version to $VERSION"
 echo "Creating tag v$VERSION..."
 git tag "v$VERSION"
 
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
 echo "Done!"
 echo "Next steps:"
-echo "1. git push origin $BRANCH"
-echo "2. git push origin v$VERSION"
-if [ "$BRANCH" != "main" ]; then
-    echo "3. Create a PR to merge '$BRANCH' into main"
-    echo "   gh pr create --title 'chore: release v$VERSION' --body 'Bump version to $VERSION'"
-    echo "4. After merge, push the tag: git push origin v$VERSION"
-    echo "5. Check GitHub Actions for the Release process."
-else
-    echo "3. Check GitHub Actions for the Release process."
-fi
+echo "1. git push -u origin $BRANCH"
+echo "2. gh pr create --title \"chore: release v$VERSION\" --body \"Bump version to $VERSION\""
+echo "3. After merge, push the tag: git push origin v$VERSION"
+echo "4. Check GitHub Actions for the Release process."


### PR DESCRIPTION
## Summary

\`scripts/release.sh\` used to run on any branch and only print a hint about creating a PR when not on \`main\`. Running it from \`main\` accidentally commits a version bump directly to \`main\`, bypassing PR review, CI, and the merge audit trail. This happened today — two stray local commits had to be reset.

This PR adds an explicit guard: if HEAD is on \`main\`, the script prints the proper 5-step workflow and exits 1 before touching any file. No env-var escape hatch — normalising the wrong path is what caused the incident in the first place.

## Behaviour

**Before:** running on main silently committed the version bump to main; a footer suggested a PR but the bump was already on the wrong branch.

**After:**

\`\`\`
\$ git checkout main
\$ ./scripts/release.sh 1.3.9
Error: refusing to run release from 'main' branch.

Version bumps must go through a PR:
  1. git checkout -b chore/release-v1.3.9
  2. ./scripts/release.sh 1.3.9   # re-run on the release branch
  3. git push -u origin chore/release-v1.3.9
  4. gh pr create --title \"chore: release v1.3.9\" --body \"Bump version to 1.3.9\"
  5. Merge once CI is green, then push the tag.
\`\`\`

On any non-main branch, the script proceeds normally.

## Also in this PR

- Dropped the dead \`if [ "\$BRANCH" != "main" ]\` footer branch — \`BRANCH = main\` is now unreachable past the guard, so collapsed the \"Next steps\" to the single correct path.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 264/264
- [x] Dry-run on \`chore/release-guard\` branch — script proceeds past the guard (made a throwaway 9.9.9 commit, rolled back)
- [x] Dry-run on \`main\` — script prints the 5-step workflow and exits 1; \`package.json\` / \`gemini-extension.json\` / \`plugin.json\` are not modified

## Follow-up (after this merges)

Re-do the 1.3.9 release the proper way:

1. \`git checkout main && git pull\`
2. \`git checkout -b chore/release-v1.3.9\`
3. \`./scripts/release.sh 1.3.9\`
4. Push the branch, open the release PR, merge, push the tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hard guard in `scripts/release.sh` to refuse running on `main`, forcing releases to go through a release branch and PR. This prevents accidental version bumps on `main` and ensures CI and review run every time.

- **Refactors**
  - Detect `main`, print a 5-step release workflow, and exit 1 before touching files.
  - Remove the dead `if [ "$BRANCH" != "main" ]` branch and simplify “Next steps” to the single PR path (push branch, open PR, push tag after merge).

<sup>Written for commit 468bf4f7bdb24630fb030ac93d21eb4c3d873eaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

