### PR TITLE
chore: release v1.3.9

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.3.9 by bumping the version from 1.3.8 to 1.3.9 across manifests to keep the plugin and extension aligned. Updated `package.json`, `.gemini-plugin/plugin.json`, and `gemini-extension.json`.

<sup>Written for commit 8590daa3b7c2cedd865da22c38fd2e8127a2204e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

