### PR TITLE
chore: release v1.3.10

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.9",
+	"version": "1.3.10",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.9",
+	"version": "1.3.10",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.9",
+	"version": "1.3.10",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.10

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v1.3.10 release by bumping versions from 1.3.9 to 1.3.10 in `package.json`, `.gemini-plugin/plugin.json`, and `gemini-extension.json`. No runtime changes; resolved merge conflicts and aligned metadata for publish.

<sup>Written for commit 3571c3a85107b268c45e940f53f7704b32d58e9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

