### PR TITLE
docs: triage ECC upstream commits 4e66b288..e9c88458

### DIFF
--- a/upstream/sync-rounds/2026-05-12.md
+++ b/upstream/sync-rounds/2026-05-12.md
@@ -1,0 +1,228 @@
+# Upstream sync inventory — 2026-05-12
+
+A categorized commit-by-commit triage of the ECC drift recorded by [#60](https://github.com/Jamkris/everything-gemini-code/issues/60). This file is the audit log for the sync round: which upstream commits were evaluated, what we plan to port, and what we are skipping with what rationale.
+
+The actual port PRs follow this inventory and reference rows from the tables below by SHA.
+
+## Range
+
+- **Recorded baseline** in `upstream/.upstream-sync.json`: [`9db98673`](https://github.com/affaan-m/everything-claude-code/commit/9db98673d054f5ed0991ba9d67ff4c883c81a42f) (2026-02-09)
+- **Informal cutoff (already covered by hand)**: [`4e66b288`](https://github.com/affaan-m/everything-claude-code/commit/4e66b2882da9afb9747468b08a253ca2f09c85f3) (2026-04-21) — `docs: fix plugin quick start for continuous learning v2 (#1546)`
+- **Upstream HEAD at triage time**: [`e9c88458`](https://github.com/affaan-m/everything-claude-code/commit/e9c8845833415204db993a3b0d0bf337fded23da) (2026-05-11) — `feat: add Astraflow provider support`
+
+**Total drift**: 1526 commits.
+**Focused range for this round**: 4e66b288..e9c88458 = **159 commits**.
+**Older range (9db98673..4e66b288)**: 1367 commits — see "Older range" section below for the en-bloc skip rationale.
+
+## Triage method
+
+Each commit in the focused range was bucketed by the set of paths it touches. Buckets are mutually exclusive; the first matching rule wins:
+
+| Rule | Bucket |
+|---|---|
+| Touches any of `.claude-plugin/`, `.codex-plugin/`, `.opencode/`, `.kiro/`, `.agents/`, `legacy-command-shims/`, `manifests/`, `src/`, `plugins/`, `agent.yaml`, `ecc_dashboard.py` | **D** — other-harness or ECC-runtime-specific |
+| Touches `agents/` (top-level) | **B** — translatable agents |
+| Touches `commands/` | **C** — command format translation |
+| Touches `skills/` | **A:skills** |
+| Touches `rules/` | **A:rules** |
+| Touches `scripts/`, `schemas/`, `hooks/` | **E** — shared logic |
+| All-tests-only | **E** — shared logic |
+| Touches `.github/` | **F** — CI / packaging |
+| All-paths-only meta files (`package.json`, `VERSION`, `yarn.lock`) or subject is `Merge`/`chore: release/bump` | **H** — meta |
+| All-paths match doc patterns (`docs/`, `README*`, `AGENTS.md`, etc.) | **A:docs** |
+| Otherwise | **X** — needs human read |
+
+Bucket totals for the focused 159-commit range:
+
+| Bucket | Count |
+|---|---|
+| A:skills | 14 |
+| A:rules | 0 |
+| A:docs | 14 |
+| B:agents | 0 |
+| C:commands | 9 |
+| E:shared-logic | 63 |
+| F:ci/packaging | 2 |
+| D:other-harness | 41 |
+| H:meta | 8 |
+| X:needs-review | 8 |
+| **Total** | **159** |
+
+## A:skills (14)
+
+EGC already ships matching skills for `agent-payment-x402`, `backend-patterns`, `configure-ecc`, `continuous-learning`, `continuous-learning-v2`, `deep-research`, `exa-search`, `fal-ai-media`, `strategic-compact` — those updates are eligible to port. New ECC skills with no EGC counterpart (`gateguard`, `tinystruct-patterns`, `ios-icon-gen`, `flox-environments`) are eligible too but out of scope for this round unless a follow-up explicitly opts in.
+
+| SHA | Subject | Disposition | Notes |
+|---|---|---|---|
+| `fd95cf6` | fix: retry observer wait after signal | **port** | EGC has `skills/continuous-learning-v2/` — port observer-loop.sh change |
+| `803abe5` | fix: clarify configure-ecc skill copy roots | **skip** | ECC-specific copy paths (`~/.claude/`) — EGC's `configure-ecc` skill targets `~/.gemini/` already |
+| `d05855b` | test: handle missing configure-ecc docs cleanly | **skip** | follows `803abe5` — ECC-only |
+| `cfe770a` | fix: add gateguard recovery escape hatch | **skip** | EGC has no `gateguard` skill (ECC plugin gate system) |
+| `105b524` | docs(strategic-compact): fix hook command path in SKILL.md (#1682) | **port** | EGC has `skills/strategic-compact/`; fix hook command path translation |
+| `f01929c` | feat: add tinystruct-patterns skill | **defer** | Net-new skill, harness-agnostic — eligible but bigger scope than this round |
+| `754bdbf` | feat: add ios-icon-gen skill | **defer** | Net-new skill, harness-agnostic — eligible but bigger scope |
+| `f8a0c4f` | feat(skills): add flox-environments skill | **defer** | Net-new skill, harness-agnostic — eligible but bigger scope |
+| `7b96440` | fix: bypass GateGuard file gates in subagents | **skip** | GateGuard is ECC-only |
+| `2750884` | fix: sync skill frontmatter and catalog counts | **skip** | Touches `scripts/ci/catalog.js` (ECC-only catalog) |
+| `12e1bc4` | fix: port continuous-learning observer fixes | **port** | EGC has `continuous-learning-v2` skill; portable observer fixes |
+| `d8f879e` | docs: salvage focused skill curation updates (#1723) | **port** | Touches `backend-patterns`, `deep-research`, `exa-search`, `fal-ai-media` — EGC has all four |
+| `9b385c9` | fix: salvage stale PR plugin install fixes | **skip** | Touches `scripts/harness-audit.js` paths specific to ECC plugin installer |
+| `e5229ce` | docs: salvage x402 payment skill update | **port** | EGC has `skills/agent-payment-x402/` |
+
+**Round-2 port targets from A:skills**: `fd95cf6`, `105b524`, `12e1bc4`, `d8f879e`, `e5229ce` (5 commits).
+
+## A:rules (0)
+
+No upstream rule changes in the focused range.
+
+## A:docs (14)
+
+Most A:docs commits are ECC release-cycle docs (RC1 launch, manifests, plugin install paths) that have no EGC analogue. A small minority are translatable.
+
+| SHA | Subject | Disposition | Notes |
+|---|---|---|---|
+| `530088c` | docs: remove unicode safety violations from hook addendum | **skip** | ECC hook addendum doc; not in EGC |
+| `6c8a6bd` | docs: remove unicode markers from hook addendum | **skip** | same |
+| `84ac76f` | docs: sync session storage paths across translations | **skip** | ECC plugin session paths |
+| `2bb88cf` | docs(strategic-compact): fix hook command path in zh-CN/zh-TW/ja-JP SKILL.md | **partial port** | EGC has ko-KR/zh-CN of strategic-compact — port the same path fix to those mirrors |
+| `d352270` | docs: port Russian README translation (#1722) | **skip** | EGC has en/ko-KR/zh-CN; Russian is out of scope |
+| `7a30b22` | docs: deduplicate codex hook script paths | **skip** | Codex-specific |
+| `aa12d12` | docs: align rc1 launch checklist | **skip** | ECC RC1 release |
+| `ef74dc7` | docs: refresh codex skill quickstart | **skip** | Codex-specific |
+| `33f1aa9` | docs: refresh release checklist | **skip** | ECC release cycle |
+| `b0b46c4` | docs: codex skill ports | **skip** | Codex-specific |
+| `00bc8ad` | docs: refresh cross-harness docs | **skip** | Multi-harness architecture; not relevant to EGC's narrower Gemini-CLI scope |
+| `30b07b0` | docs: refresh rc1 release announcement | **skip** | ECC RC1 |
+| `bda1f99` | docs: add ecc2 changelog draft | **skip** | ECC2 release |
+| `74dbb52` | docs: ecc2 rc1 launch summary | **skip** | ECC RC1 |
+
+**Round-2 port targets from A:docs**: `2bb88cf` (1 commit — partial; only the path fix in the translated SKILL.md mirrors).
+
+## B:agents (0)
+
+No top-level `agents/` changes in the focused range. (Many `.agents/` changes exist but those are ECC's runtime-specific agent definitions and live in bucket D.)
+
+## C:commands (9)
+
+EGC commands use `.toml` format with `egc-` prefix; ECC uses `.md`. Translation cost is per-commit. The bulk of this bucket is `loop-status` (an ECC-only command), which is skipped wholesale.
+
+| SHA | Subject | Disposition | Notes |
+|---|---|---|---|
+| `17aafc4` | fix: make plan command work without planner agent | **port** | EGC has `commands/egc-plan.toml`; the intent (graceful degradation when planner agent missing) translates |
+| `01d3743` | fix: add command metadata frontmatter | **skip** | EGC commands already have TOML `description` field — frontmatter concept doesn't translate cleanly |
+| `b8452dc` | feat: add loop status transcript inspector | **skip** | `loop-status` is an ECC plugin command |
+| `fb6cc85` | fix: harden loop status transcript scanning | **skip** | same |
+| `38f4265` | feat: add loop-status watch mode | **skip** | same |
+| `fbd441b` | feat: add loop-status exit-code mode | **skip** | same |
+| `7b03a60` | fix: require bounded loop-status exit-code watch | **skip** | same |
+| `4c8499d` | docs: clarify loop-status exit-code watch constraint | **skip** | same |
+| `20154dd` | feat: write loop-status snapshots | **skip** | same |
+
+**Round-2 port targets from C:commands**: `17aafc4` (1 commit).
+
+## E:shared-logic (63)
+
+The largest bucket; most of it is ECC-runtime infrastructure that EGC does not have (loop-status, consult, work-items, status, state-store, gateguard hooks, InsAIts security monitor, ECC's cursor/codex/opencode install targets). The portable subset is the small number of fixes to hooks and CI validators that EGC also runs.
+
+EGC's matching files (verified): `scripts/hooks/block-no-verify.js`, `scripts/hooks/session-start.js`, `scripts/hooks/session-end.js`, `scripts/hooks/check-console-log.js`, `scripts/hooks/pre-compact.js`, `scripts/hooks/suggest-compact.js`, `scripts/hooks/evaluate-session.js`, `scripts/hooks/run.js`, `scripts/ci/validate-{agents,commands,hooks,skills,workflow-security,upstream-sync}.js`.
+
+### Portable subset
+
+| SHA | Subject | Disposition | Notes |
+|---|---|---|---|
+| `0dcde13` | fix: parse block-no-verify flags by shell words | **port** | EGC has `scripts/hooks/block-no-verify.js` and a test for it |
+| `e196f8a` | fix(ci): flag SKILL.md frontmatter defects in validate-skills | **port** | EGC has `scripts/ci/validate-skills.js` |
+| `d26d66f` | fix: inject learned skills at session start | **evaluate** | EGC has `scripts/hooks/session-start.js`; check whether the injection concept applies |
+| `b1456bd` | fix: cap session-start context injection | **evaluate** | follows `d26d66f` if portable |
+| `03108be` | fix: scope SessionStart context injection | **evaluate** | follows `d26d66f` if portable |
+| `3fadc37` | fix: route continuous learning observe hooks through node | **evaluate** | check whether EGC's `continuous-learning-v2` hooks shape matches |
+
+### Skipped (representative samples)
+
+The remaining 57 commits in this bucket are skipped wholesale. Representative reasons:
+- `scripts/loop-status.js`, `scripts/consult.js`, `scripts/work-items.js`, `scripts/status.js` — ECC CLI surface EGC does not have.
+- `scripts/lib/install-targets/cursor-project.js`, `scripts/install-apply.js`, `scripts/lib/cursor-agent-names.js` — ECC's installer targets (cursor / codex / opencode); EGC has its own Antigravity flow.
+- `scripts/hooks/gateguard-fact-force.js`, `scripts/hooks/insaits-security-*.{js,py}`, `scripts/hooks/mcp-health-check.js`, `scripts/hooks/pre-bash-commit-quality.js`, `scripts/hooks/post-edit-format.js` — ECC-runtime hooks not present in EGC.
+- `scripts/ci/catalog.js`, `scripts/ci/validate-no-personal-paths.js` — ECC's catalog and personal-path validators that EGC does not need.
+- `scripts/lib/state-store/`, `schemas/state-store.schema.json` — ECC's state store.
+- `scripts/harness-audit.js` (the ECC tool) — distinct from EGC's `scripts/harness-audit.js` which is a port; the upstream fixes target ECC-only behaviour.
+
+**Round-2 port targets from E:shared-logic**: `0dcde13`, `e196f8a` confirmed portable. `d26d66f`, `b1456bd`, `03108be`, `3fadc37` flagged for evaluation during the port PR (skip if EGC's hooks don't match).
+
+## F:ci/packaging (2)
+
+| SHA | Subject | Disposition | Notes |
+|---|---|---|---|
+| `01b1719` | chore(deps): bump actions/cache from 5.0.4 to 5.0.5 (#1497) | **skip** | EGC has its own dependabot |
+| `c013479` | build(deps): bump pnpm/action-setup from 6.0.0 to 6.0.6 (#1708) | **skip** | EGC has its own dependabot |
+
+## D:other-harness (41) — wholesale skip
+
+ECC RC1 ecc2 work, Codex / Cursor / OpenCode / Kiro plugin support, `.agents/` runtime configs, `agent.yaml` files, `legacy-command-shims/`, `manifests/`, ecc2 Rust sources in `src/`, the ECC dashboard. EGC consciously scopes itself to Gemini CLI + Antigravity per `upstream/README.md` — these are intentionally divergent.
+
+Representative SHAs: `0a87323` (ecc2 RC1 release surface), `a7a56fa` (auto-update for ECC plugins), `06f9eca` (retire legacy command shims), `affbd33` (opencode shell file probes).
+
+## H:meta (8) — wholesale skip
+
+7 merge commits and 1 version bump. No content of their own to port; the underlying work either landed in another commit (already bucketed) or is irrelevant.
+
+## X:needs-review (8)
+
+Edge cases — mostly docs commits that touched a test file alongside the doc and so fell through the all-paths-match-docs check.
+
+| SHA | Subject | Disposition | Notes |
+|---|---|---|---|
+| `177b8f3` | docs: clarify install and uninstall paths | **skip** | ECC plugin install paths |
+| `4b67c3c` | docs: close ecc2 rc1 release policy drift | **skip** | ECC RC1 release |
+| `69b8ec4` | docs: add ecc2 rc1 quickstart path | **skip** | ECC RC1 |
+| `a374eaf` | docs: use canonical plugin command namespace | **skip** | ECC plugin command namespace |
+| `63c97b4` | docs: align rc1 social launch copy | **skip** | ECC RC1 social launch |
+| `158cbd8` | docs: sync zh-cn rc1 release heading | **skip** | ECC RC1 |
+| `2fd8dfc` | docs: clarify MCP disable guidance | **evaluate** | Touches `docs/token-optimization.md`; EGC has `docs/en/contributing/token-optimization.md` — the MCP disable guidance may translate |
+| `6ab00d8` | fix: route backlog work from lead working dirs | **skip** | `ecc2/src/session/manager.rs` — ecc2 Rust (bucket D in spirit) |
+
+**Round-2 port targets from X:needs-review**: `2fd8dfc` (1 commit — evaluate during port).
+
+## Older range (9db98673..4e66b288) — 1367 commits, en-bloc skip for this round
+
+Quick aggregate of the older range to verify it is safe to defer en bloc:
+
+- Top paths touched: `docs/` (1883 file-touches), `skills/` (813), `tests/` (677), `.cursor/` (606), `ecc2/` (559), `scripts/` (558), `.kiro/` (273), `.opencode/` (232), `commands/` (209), `README.md` (156), `rules/` (152), `.agents/` (149).
+- The plurality of file-touches are in multi-harness plugin paths (`.cursor/`, `.kiro/`, `.opencode/`, `.agents/`, `ecc2/`) and ECC's own runtime tooling — categories EGC consciously diverges from.
+- The original EGC fork captured ECC main at the time of `ff331996` (EGC's initial commit, 2026-02-09). Skill, rule, and doc content from before that fork point is already present in EGC at the format it was forked at; ECC's subsequent edits in the 9db98673..4e66b288 range to the *same* files would only matter if a regression had landed in EGC by being out-of-sync.
+- The maintainer's hand-tracking through 4e66b288 covers any high-yield upstream change in this range that warranted attention.
+
+**Disposition**: this range is recorded as evaluated en-bloc, not commit-by-commit. The new baseline advances to 4e66b288 in this round, and the focused 159-commit range advances further as those PRs land. If a specific upstream change in the older range turns out to matter, it will be flagged in a future round as a regression discovery rather than a missed port.
+
+## Summary
+
+| Category | Port now | Evaluate during port | Defer (eligible but bigger scope) | Skip |
+|---|---|---|---|---|
+| A:skills | 5 | — | 3 (net-new skills) | 6 |
+| A:rules | 0 | — | — | 0 |
+| A:docs | 1 | — | — | 13 |
+| B:agents | 0 | — | — | 0 |
+| C:commands | 1 | — | — | 8 |
+| E:shared-logic | 2 | 4 | — | 57 |
+| F:ci/packaging | 0 | — | — | 2 |
+| D:other-harness | 0 | — | — | 41 |
+| H:meta | 0 | — | — | 8 |
+| X:needs-review | 0 | 1 | — | 7 |
+| **Total** | **9** | **5** | **3** | **142** |
+
+## Recommended follow-up PRs
+
+In suggested order, each independent and reviewable on its own:
+
+1. **`port: skill curation updates from ECC`** — covers `fd95cf6`, `105b524`, `12e1bc4`, `d8f879e`, `e5229ce`, and the `2bb88cf` translation mirror. All A:skills + A:docs port targets in one PR.
+2. **`port: hook + validator fixes from ECC`** — covers `0dcde13`, `e196f8a`. Plus per-commit evaluation of `d26d66f`, `b1456bd`, `03108be`, `3fadc37`. Drop any that don't translate cleanly; document the drop in this audit log.
+3. **`port: plan command graceful degradation`** — covers `17aafc4`. Small PR; can ride along with PR 2 if reviewers prefer.
+4. **`port: MCP disable guidance update`** — covers `2fd8dfc` if it translates. Trivial PR; can ride along with PR 1.
+5. **`docs: advance upstream baseline to e9c88458`** — updates `upstream/.upstream-sync.json` + `upstream/README.md` (+ ko-KR / zh-CN mirrors) to the SHA actually evaluated. This is the final PR of the round; it closes [#60](https://github.com/Jamkris/everything-gemini-code/issues/60) automatically when the drift workflow next runs.
+
+PRs 1–4 can land in parallel. PR 5 must be last.
+
+## Out of scope for this round
+
+- The 3 deferred net-new skills (`tinystruct-patterns`, `ios-icon-gen`, `flox-environments`). Open as a separate "ECC net-new skills" round once round 2 lands.
+- The schema split between `lastSyncedSha` and `lastEvaluatedSha` (would change the validator + drift workflow). Defer to its own PR.


### PR DESCRIPTION
## Summary

Audit log for the 2026-05-12 upstream sync round. Records the 159 commits between the maintainer's informal cutoff (\`4e66b288\`, 2026-04-21) and the current ECC HEAD (\`e9c88458\`, 2026-05-11) bucketed by path. Each commit gets a per-commit disposition (port / defer / skip) with one-line rationale.

The 1367-commit older range (\`9db98673..4e66b288\`) is recorded as evaluated en-bloc — its file-touches concentrate on multi-harness plugin paths and ECC-only runtime that EGC consciously diverges from.

Doc-only PR — no source changes here. Subsequent port PRs reference rows from \`upstream/sync-rounds/2026-05-12.md\` by SHA.

## Bucket totals (focused 159-commit range)

| Bucket | Count |
|---|---|
| A:skills | 14 |
| A:rules | 0 |
| A:docs | 14 |
| B:agents | 0 |
| C:commands | 9 |
| E:shared-logic | 63 |
| F:ci/packaging | 2 |
| D:other-harness | 41 |
| H:meta | 8 |
| X:needs-review | 8 |

## Port plan

| Category | Port now | Evaluate during port | Defer (net-new, bigger scope) | Skip |
|---|---|---|---|---|
| Skill curation | 5 | — | 3 | 6 |
| Hooks + validators | 2 | 4 | — | 57 |
| Commands | 1 | — | — | 8 |
| Docs (incl. MCP guidance) | 1 | 1 | — | 21 |
| Other (D/F/H/agents/rules) | 0 | — | — | 50 |
| **Total** | **9** | **5** | **3** | **142** |

## Follow-up PRs (in suggested order)

The audit log proposes 5 PRs; 1–4 can land in parallel, PR 5 must be last:

1. \`port: skill curation updates from ECC\` — covers \`fd95cf6\`, \`105b524\`, \`12e1bc4\`, \`d8f879e\`, \`e5229ce\`, \`2bb88cf\`
2. \`port: hook + validator fixes from ECC\` — covers \`0dcde13\`, \`e196f8a\` (+ 4 to evaluate)
3. \`port: plan command graceful degradation\` — covers \`17aafc4\` (can ride along with PR 2)
4. \`port: MCP disable guidance update\` — covers \`2fd8dfc\` if portable (can ride along with PR 1)
5. \`docs: advance upstream baseline to e9c88458\` — updates \`upstream/.upstream-sync.json\` + \`upstream/README.md\` (+ ko-KR / zh-CN mirrors). Closes [#60](https://github.com/Jamkris/everything-gemini-code/issues/60) when the drift workflow next runs.

## Out of scope

- The 3 deferred net-new ECC skills (\`tinystruct-patterns\`, \`ios-icon-gen\`, \`flox-environments\`). Worth its own round once this one lands.
- A schema split between \`lastSyncedSha\` and \`lastEvaluatedSha\`. Defer.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 264/264
- [x] Bucketing heuristic verified by sampling each bucket (skills/rules/docs/commands/hooks/CI/skip)
- [x] EGC file matches verified for every \`port\` row (e.g. \`scripts/hooks/block-no-verify.js\`, \`scripts/ci/validate-skills.js\`, \`commands/egc-plan.toml\`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `upstream/sync-rounds/2026-05-12.md`, an audit log for the 2026-05-12 upstream sync that buckets recent ECC commits and records per-commit port/skip/defer decisions plus proposed follow-up PRs. Docs-only; no source changes.

<sup>Written for commit 168920ec70928b6e81783d6b7d94925ab6080262. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added upstream synchronization audit log documenting commit triage and disposition tracking for the current release round.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jamkris/everything-gemini-code/pull/66)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->