### PR TITLE
port: skill curation updates from ECC

### DIFF
--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -1,21 +1,40 @@
 ---
 name: agent-payment-x402
-description: Add x402 payment execution to AI agents — per-task budgets, spending controls, and non-custodial wallets via MCP tools. Use when agents need to pay for APIs, services, or other agents.
+description: Add x402 payment execution to AI agents with per-task budgets, spending controls, and non-custodial wallets. Supports Base through agentwallet-sdk and X Layer through OKX Payments / OKX Agent Payments Protocol.
 origin: community
 ---
 
 # Agent Payment Execution (x402)
 
-Enable AI agents to make autonomous payments with built-in spending controls. Uses the x402 HTTP payment protocol and MCP tools so agents can pay for external services, APIs, or other agents without custodial risk.
+Enable AI agents to make policy-gated payments with built-in spending controls. Uses the x402 HTTP payment protocol and MCP tools so agents can pay for external services, APIs, or other agents without custodial risk.
 
 ## When to Use
 
 Use when: your agent needs to pay for an API call, purchase a service, settle with another agent, enforce per-task spending limits, or manage a non-custodial wallet. Pairs naturally with cost-aware-llm-pipeline and security-review skills.
 
+## Decision Tree
+
+Choose the integration path based on whether your agent is buying access to a paid API or charging others for one:
+
+| Need | Recommended path |
+|------|------------------|
+| Agent pays a 402-gated API on Base or another agentwallet-supported chain | Use `agentwallet-sdk` as an MCP payment server with strict spending policy |
+| Agent pays a 402-gated API on X Layer | Use OKX Agent Payments Protocol from `okx/onchainos-skills`; `okx-x402-payment` is a deprecated legacy alias |
+| TypeScript API charges agents | Use OKX Payments TypeScript seller SDK docs for Express, Hono, Fastify, or Next.js |
+| Go API charges agents | Use OKX Payments Go seller SDK docs for Gin, Echo, or `net/http` |
+| Rust API charges agents | Use OKX Payments Rust seller SDK docs for Axum |
+| Java API charges agents | Use OKX Payments Java seller SDK docs for Spring Boot 2/3, Java EE, or Jakarta |
+| Python API charges agents | Check the current OKX Payments repository before implementation; a Python seller guide may not be available |
+
+## Supported Networks
+
+- `agentwallet-sdk`: use the package docs to confirm current network coverage before production. Base Sepolia is the safest development default; Base mainnet is the production path called out by the original skill.
+- OKX Payments / X Layer: current seller docs target X Layer (`eip155:196`) and USDT0 settlement. Fetch current SDK docs before generating production code because payment packages and facilitator behavior can change quickly.
+
 ## How It Works
 
 ### x402 Protocol
-x402 extends HTTP 402 (Payment Required) into a machine-negotiable flow. When a server returns `402`, the agent's payment tool automatically negotiates price, checks budget, signs a transaction, and retries — no human in the loop.
+x402 extends HTTP 402 (Payment Required) into a machine-negotiable flow. When a server returns `402`, the agent's payment tool negotiates price, checks budget, signs a transaction, and retries only inside the policy and confirmation boundary set by the orchestrator.
 
 ### Spending Controls
 Every payment tool call enforces a `SpendingPolicy`:
@@ -32,6 +51,8 @@ Agents hold their own keys via ERC-4337 smart accounts. The orchestrator sets po
 The payment layer exposes standard MCP tools that slot into any Gemini CLI or agent harness setup.
 
 > **Security note**: Always pin the package version. This tool manages private keys — unpinned `npx` installs introduce supply-chain risk.
+
+### Option A: agentwallet-sdk (Base / multi-chain)
 
 ```json
 {
@@ -54,6 +75,28 @@ The payment layer exposes standard MCP tools that slot into any Gemini CLI or ag
 | `list_transactions` | Audit trail of all payments |
 
 > **Note**: Spending policy is set by the **orchestrator** before delegating to the agent — not by the agent itself. This prevents agents from escalating their own spending limits. Configure policy via `set_policy` in your orchestration layer or pre-task hook, never as an agent-callable tool.
+
+### Option B: OKX Agent Payments Protocol (X Layer)
+
+Use this path for X Layer x402, Multi-Party Payment (MPP), session payment, charge, and A2A charge flows.
+
+For buyer-side agent flows:
+
+1. Install or reference the current `okx/onchainos-skills` repository.
+2. Use `skills/okx-agent-payments-protocol/SKILL.md` as the dispatcher.
+3. Treat `skills/okx-x402-payment/SKILL.md` as a deprecated compatibility alias, not as the canonical skill.
+4. Require explicit user confirmation before wallet status checks or payment actions. Do not hide payment execution behind a generic tool call.
+
+For seller-side API flows, fetch the latest language-specific guide before generating code:
+
+| Runtime | Current guide |
+|---------|---------------|
+| TypeScript | `https://raw.githubusercontent.com/okx/payments/main/typescript/SELLER.md` |
+| Go | `https://raw.githubusercontent.com/okx/payments/main/go/x402/SELLER.md` |
+| Rust | `https://raw.githubusercontent.com/okx/payments/main/rust/x402/SELLER.md` |
+| Java | `https://raw.githubusercontent.com/okx/payments/main/java/SELLER.md` |
+
+Do not copy examples from older docs without checking the current OKX repository. Current OKX guidance uses `okx-agent-payments-protocol` as the dispatcher, and Java seller docs are now available.
 
 ## Examples
 
@@ -176,3 +219,6 @@ main().catch((err) => {
 - **npm**: [`agentwallet-sdk`](https://www.npmjs.com/package/agentwallet-sdk)
 - **Merged into NVIDIA NeMo Agent Toolkit**: [PR #17](https://github.com/NVIDIA/NeMo-Agent-Toolkit-Examples/pull/17) — x402 payment tool for NVIDIA's agent examples
 - **Protocol spec**: [x402.org](https://x402.org)
+- **OKX Payments SDKs**: [`okx/payments`](https://github.com/okx/payments) — TypeScript, Go, Rust, and Java seller integrations for X Layer x402
+- **OKX Agent Payments Protocol skill**: [`okx/onchainos-skills`](https://github.com/okx/onchainos-skills/tree/main/skills/okx-agent-payments-protocol)
+- **OKX Payments overview**: [web3.okx.com/onchainos/dev-docs/payments/overview](https://web3.okx.com/onchainos/dev-docs/payments/overview)

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -82,9 +82,9 @@ Use this path for X Layer x402, Multi-Party Payment (MPP), session payment, char
 
 For buyer-side agent flows:
 
-1. Install or reference the current `okx/onchainos-skills` repository.
-2. Use `skills/okx-agent-payments-protocol/SKILL.md` as the dispatcher.
-3. Treat `skills/okx-x402-payment/SKILL.md` as a deprecated compatibility alias, not as the canonical skill.
+1. Install or reference the current [`okx/onchainos-skills`](https://github.com/okx/onchainos-skills) repository — these skills live in that external repo, not in EGC.
+2. Use [`okx-agent-payments-protocol`](https://github.com/okx/onchainos-skills/tree/main/skills/okx-agent-payments-protocol) (in the `okx/onchainos-skills` repo) as the dispatcher.
+3. Treat [`okx-x402-payment`](https://github.com/okx/onchainos-skills/tree/main/skills/okx-x402-payment) (same repo) as a deprecated compatibility alias, not as the canonical skill.
 4. Require explicit user confirmation before wallet status checks or payment actions. Do not hide payment execution behind a generic tool call.
 
 For seller-side API flows, fetch the latest language-specific guide before generating code:

--- a/skills/backend-patterns/SKILL.md
+++ b/skills/backend-patterns/SKILL.md
@@ -419,51 +419,14 @@ export const DELETE = requirePermission('delete')(
 
 ## Rate Limiting
 
-### Simple In-Memory Rate Limiter
+Rate limiting must use a shared store such as Redis, a gateway, or the
+platform's native limiter. Do not use per-process in-memory counters for
+production APIs: they reset on deploy, split across replicas, and fail open in
+serverless or multi-instance environments.
 
-```typescript
-class RateLimiter {
-  private requests = new Map<string, number[]>()
-
-  async checkLimit(
-    identifier: string,
-    maxRequests: number,
-    windowMs: number
-  ): Promise<boolean> {
-    const now = Date.now()
-    const requests = this.requests.get(identifier) || []
-
-    // Remove old requests outside window
-    const recentRequests = requests.filter(time => now - time < windowMs)
-
-    if (recentRequests.length >= maxRequests) {
-      return false  // Rate limit exceeded
-    }
-
-    // Add current request
-    recentRequests.push(now)
-    this.requests.set(identifier, recentRequests)
-
-    return true
-  }
-}
-
-const limiter = new RateLimiter()
-
-export async function GET(request: Request) {
-  const ip = request.headers.get('x-forwarded-for') || 'unknown'
-
-  const allowed = await limiter.checkLimit(ip, 100, 60000)  // 100 req/min
-
-  if (!allowed) {
-    return NextResponse.json({
-      error: 'Rate limit exceeded'
-    }, { status: 429 })
-  }
-
-  // Continue with request
-}
-```
+Keep the backend layer responsible for choosing the integration point and error
+shape; use `api-design` for the HTTP contract and `security-review` for abuse
+case review.
 
 ## Background Jobs & Queues
 

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -6,6 +6,10 @@ origin: ECC
 
 # Deep Research
 
+> **Drift-prone skill.** Firecrawl/Exa MCP tool names, quotas, and result
+> shapes change. Verify the configured MCP tools and current API docs before
+> promising coverage or quoting live source counts.
+
 Produce thorough, cited research reports from multiple web sources using firecrawl and exa MCP tools.
 
 ## When to Use

--- a/skills/exa-search/SKILL.md
+++ b/skills/exa-search/SKILL.md
@@ -6,6 +6,10 @@ origin: ECC
 
 # Exa Search
 
+> **Drift-prone skill.** Exa MCP tool names, parameters, and account limits can
+> change. Confirm the exposed tool surface and current Exa docs before relying
+> on a specific search mode, category, or livecrawl behavior.
+
 Neural search for web content, code, companies, and people via the Exa MCP server.
 
 ## When to Use

--- a/skills/fal-ai-media/SKILL.md
+++ b/skills/fal-ai-media/SKILL.md
@@ -6,6 +6,10 @@ origin: ECC
 
 # fal.ai Media Generation
 
+> **Drift-prone skill.** fal.ai model IDs, pricing, inputs, and MCP tool names
+> change quickly. Search or fetch the current model metadata before promising a
+> specific model, parameter, output format, or cost.
+
 Generate images, videos, and audio using fal.ai models via MCP.
 
 ## When to Use

--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -160,8 +160,8 @@ Result: Zero custom code, battle-tested solution
 ```
 Need: Resilient HTTP client with retries and timeout handling
 Search: npm "http client retry", PyPI "httpx retry"
-Found: got (Node) with retry plugin, httpx (Python) with built-in retry
-Action: ADOPT — use got/httpx directly with retry config
+Found: undici (Node) with retry interceptor, httpx (Python) with built-in retry
+Action: ADOPT — use undici/httpx directly with retry config
 Result: Zero custom code, production-proven libraries
 ```
 

--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -20,6 +20,10 @@ Use this skill when:
 
 ```
 ┌─────────────────────────────────────────────┐
+│  0. TOOL AVAILABILITY PREFLIGHT             │
+│     Check search channels before relying on │
+│     them; report skipped channels honestly   │
+├─────────────────────────────────────────────┤
 │  1. NEED ANALYSIS                           │
 │     Define what functionality is needed      │
 │     Identify language/framework constraints  │
@@ -57,6 +61,19 @@ Use this skill when:
 
 ## How to Use
 
+### Step 0: Tool Availability Preflight
+
+This is agent guidance, not an executable setup script. Check only the channels
+that are relevant to the task and project in front of you.
+
+| Channel | Check | If missing |
+|---------|-------|------------|
+| Repository search | `rg --files` and targeted `rg` queries | State that only visible files were inspected |
+| Package registry | `npm --version`, `python -m pip --version`, or project package manager | Use web/docs search and avoid claiming registry coverage |
+| GitHub CLI | `gh auth status` | Use public web or local git history only |
+| MCP/docs tools | Available tool list or local MCP config | Fall back to official docs/web search |
+| Skills directory | `ls ~/.gemini/skills` | Say no local skill catalog was available |
+
 ### Quick Mode (inline)
 
 Before writing a utility or adding functionality, mentally run through:
@@ -82,6 +99,10 @@ Task(subagent_type="general-purpose", prompt="
 ")
 ```
 
+The exact subagent/dispatch tool name depends on the active harness — use the
+name your current Gemini CLI / Antigravity surface exposes rather than copying
+the example verbatim.
+
 ## Search Shortcuts by Category
 
 ### Development Tooling
@@ -96,7 +117,7 @@ Task(subagent_type="general-purpose", prompt="
 - Document processing → `unstructured`, `pdfplumber`, `mammoth`
 
 ### Data & APIs
-- HTTP clients → `httpx` (Python), `ky`/`got` (Node)
+- HTTP clients → `httpx` (Python), `ky`/`undici` (Node)
 - Validation → `zod` (TS), `pydantic` (Python)
 - Database → Check for MCP servers first
 
@@ -157,5 +178,6 @@ Result: 1 package + 1 schema file, no custom validation logic
 
 - **Jumping to code**: Writing a utility without checking if one exists
 - **Ignoring MCP**: Not checking if an MCP server already provides the capability
+- **Silent skipping**: Reporting "nothing found" when a search channel was unavailable
 - **Over-customizing**: Wrapping a library so heavily it loses its benefits
 - **Dependency bloat**: Installing a massive package for one small feature

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -207,6 +207,11 @@ function renderUserContent(html: string) {
 ```
 
 #### Content Security Policy
+
+Start strict and loosen only with a documented removal plan. Do not default to
+`'unsafe-inline'` or `'unsafe-eval'`; they neutralize much of CSP's protection
+and should be treated as temporary compatibility debt.
+
 ```typescript
 // next.config.js
 const securityHeaders = [
@@ -214,8 +219,11 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: `
       default-src 'self';
-      script-src 'self' 'unsafe-eval' 'unsafe-inline';
-      style-src 'self' 'unsafe-inline';
+      base-uri 'self';
+      object-src 'none';
+      frame-ancestors 'none';
+      script-src 'self';
+      style-src 'self';
       img-src 'self' data: https:;
       font-src 'self';
       connect-src 'self' https://api.example.com;

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -21,7 +21,7 @@ Strategic compaction at logical boundaries:
 
 ## How It Works
 
-The `suggest-compact.sh` script runs on PreToolUse (Edit/Write) and:
+The `suggest-compact.js` script runs on PreToolUse (Edit/Write) and:
 
 1. **Tracks tool calls** - Counts tool invocations in session
 2. **Threshold detection** - Suggests at configurable threshold (default: 50 calls)
@@ -38,7 +38,7 @@ Add to your `~/.gemini/settings.json`:
       "matcher": "tool == \"Edit\" || tool == \"Write\"",
       "hooks": [{
         "type": "command",
-        "command": "~/.gemini/skills/strategic-compact/suggest-compact.sh"
+        "command": "node ~/.gemini/scripts/hooks/suggest-compact.js"
       }]
     }]
   }

--- a/skills/x-api/SKILL.md
+++ b/skills/x-api/SKILL.md
@@ -6,6 +6,10 @@ origin: ECC
 
 # X API
 
+> **Drift-prone skill.** X API endpoints, access tiers, quotas, and write
+> permissions change frequently. Verify current developer docs and account
+> access before quoting rate limits or implementing a posting/search flow.
+
 Programmatic interaction with X (Twitter) for posting, reading, searching, and analytics.
 
 ## When to Use


### PR DESCRIPTION
## Summary

First port PR from the 2026-05-12 upstream sync round (audit log: [\`upstream/sync-rounds/2026-05-12.md\`](https://github.com/Jamkris/everything-gemini-code/blob/main/upstream/sync-rounds/2026-05-12.md)).

Ports the safe, narrow skill curation work from ECC's PR #1723 plus three smaller drift-related changes from neighbouring commits. All harness-agnostic content; no source / hook / script behavior changes.

## Files changed (9)

| File | Source SHA | Change |
|---|---|---|
| \`skills/agent-payment-x402/SKILL.md\` | \`e5229ce\` | Decision tree (Base vs X Layer), Option A/B MCP integration, OKX Payments seller SDK guides, expanded sources |
| \`skills/backend-patterns/SKILL.md\` | \`d8f879e\` | Replace unsafe in-memory rate limiter example with a paragraph pointing at shared-store solutions |
| \`skills/deep-research/SKILL.md\` | \`d8f879e\` | Drift-prone-skill warning |
| \`skills/exa-search/SKILL.md\` | \`d8f879e\` | Drift-prone-skill warning |
| \`skills/fal-ai-media/SKILL.md\` | \`d8f879e\` | Drift-prone-skill warning |
| \`skills/x-api/SKILL.md\` | \`d8f879e\` | Drift-prone-skill warning |
| \`skills/search-first/SKILL.md\` | \`d8f879e\` | New Step 0 preflight + table, \`ky/got\` → \`ky/undici\`, \"Silent skipping\" anti-pattern, harness-current subagent dispatch note |
| \`skills/security-review/SKILL.md\` | \`d8f879e\` | CSP example tightened (no \`'unsafe-inline'\`/\`'unsafe-eval'\` defaults; added \`base-uri\`/\`object-src\`/\`frame-ancestors\`) |
| \`skills/strategic-compact/SKILL.md\` | \`105b524\` | Fix broken hook path in Setup example (\`~/.gemini/skills/.../suggest-compact.sh\` → \`node ~/.gemini/scripts/hooks/suggest-compact.js\`); fix the \`.sh\` vs \`.js\` prose reference |

## ECC commits in scope that did not port

- \`fd95cf6\` (observer-loop.sh signal retry) — EGC's \`continuous-learning-v2\` uses a different observer architecture (no long-lived Claude child PID waited on), so the SIGUSR1 wait-interrupt bug doesn't apply.
- \`12e1bc4\` (continuous-learning storage migration) — bulk of the commit moves user data away from \`~/.claude/homunculus/\` because of Claude Code's sensitive-path guard. EGC has no such guard, existing users live at \`~/.gemini/homunculus/\`, so the migration creates risk without benefit. Better as a dedicated PR if revisited.
- \`2bb88cf\` (strategic-compact translation mirrors) — n/a, EGC doesn't maintain per-language SKILL.md mirrors under \`skills/\`.

These skips are also recorded in the audit log so the precedent is auditable.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` 264/264
- [x] Each ported file's hook-path / tool-name / paths verified against EGC's actual layout (e.g. \`scripts/hooks/suggest-compact.js\` exists at the claimed location; \`~/.gemini/skills\` is the correct install path)
- [x] No Claude-specific paths leaked into ported content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports curated updates to several skills to improve safety, clarity, and payment integration options. No changes to sources, hooks, or script behavior.

- **New Features**
  - `agent-payment-x402`: Added decision tree and network guidance. Supports Base via `agentwallet-sdk` and X Layer via OKX Agent Payments Protocol. Linked seller SDK guides and clarified that OKX skills live in the external `okx/onchainos-skills` repo (with `okx-x402-payment` noted as deprecated). Language softened to policy-gated.
  - `search-first`: Added Step 0 tool-availability preflight. Updated HTTP client tip from `ky/got` to `ky/undici` and aligned Example 2 to use `undici`. Noted harness-specific subagent names. Added “silent skipping” anti-pattern.
  - `backend-patterns`: Replaced unsafe in-memory rate limiter example with guidance to use shared stores (Redis/gateway/platform).
  - `security-review`: Tightened CSP example (no `'unsafe-inline'`/`'unsafe-eval'`; added `base-uri`, `object-src`, `frame-ancestors`).
  - `deep-research`, `exa-search`, `fal-ai-media`, `x-api`: Added “drift-prone skill” warnings to check current tool names, limits, and result shapes.

- **Bug Fixes**
  - `strategic-compact`: Fixed setup example to use `node ~/.gemini/scripts/hooks/suggest-compact.js` and corrected `.sh` → `.js` reference.

<sup>Written for commit 337977f8b5e04683e15a2442e4f35f482953511c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded payment skill docs with a decision tree, buyer/seller integration options, guidance on supported networks, and updated production references.
  * Added drift-prone warnings across several skills to verify current APIs, tools, quotas, and models before production use.
  * Clarified rate-limiting guidance to prefer shared stores (e.g., Redis) and tightened Content Security Policy recommendations.
  * Improved tool-availability preflight guidance and updated a referenced hook script and HTTP client recommendation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jamkris/everything-gemini-code/pull/67)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->