### PR TITLE
port: plan command graceful degradation

### DIFF
--- a/commands/egc-plan.toml
+++ b/commands/egc-plan.toml
@@ -2,7 +2,9 @@ description = "Restate requirements, assess risks, and create step-by-step imple
 prompt = '''
 # Plan Command
 
-This command invokes the **planner** agent to create a comprehensive implementation plan before writing any code.
+This command creates a comprehensive implementation plan before writing any code.
+
+Run inline by default. Do not delegate to the `@planner` subagent (or any other) by default. This keeps `/egc-plan` usable when the runtime ships commands without the matching agent files.
 
 ## What This Command Does
 
@@ -22,7 +24,7 @@ Use `/egc-plan` when:
 
 ## How It Works
 
-The planner agent will:
+The assistant will:
 
 1. **Analyze the request** and restate requirements in clear terms
 2. **Break down into phases** with specific, actionable steps
@@ -36,7 +38,7 @@ The planner agent will:
 ```
 User: /egc-plan I need to add real-time notifications when markets resolve
 
-Agent (planner):
+Assistant:
 # Implementation Plan: Real-Time Market Resolution Notifications
 
 ## Requirements Restatement
@@ -91,7 +93,7 @@ Agent (planner):
 
 ## Important Notes
 
-**CRITICAL**: The planner agent will **NOT** write any code until you explicitly confirm the plan with "yes" or "proceed" or similar affirmative response.
+**CRITICAL**: This command will **NOT** write any code until you explicitly confirm the plan with "yes" or "proceed" or similar affirmative response.
 
 If you want changes, respond with:
 - "modify: [your changes]"
@@ -105,7 +107,9 @@ After planning:
 - Use `/build-and-fix` if build errors occur
 - Use `/egc-code-review` to review completed implementation
 
-## Related Agents
+## Optional Planner Agent
 
-This command invokes the `@planner` agent.
+EGC ships a `planner` agent (`agents/planner.md`) that can produce richer plans for larger features. Use it only when the local runtime already exposes that subagent and the user explicitly asks you to delegate planning — invoke as `@planner`.
+
+If the `@planner` subagent is unavailable (e.g. agents were not installed, or the runtime cannot resolve the name), continue planning inline instead of surfacing an "Agent type 'planner' not found" error.
 '''

--- a/tests/commands/plan-command.test.js
+++ b/tests/commands/plan-command.test.js
@@ -1,0 +1,95 @@
+/**
+ * Tests for commands/egc-plan.toml prompt contract.
+ *
+ * Adapted from ECC's tests/commands/plan-command.test.js (commit 17aafc4).
+ * Verifies that /egc-plan runs inline by default and does not require
+ * the planner agent to be installed.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const planCommandPath = path.join(repoRoot, 'commands', 'egc-plan.toml');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed += 1;
+  } catch (err) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${err.message}`);
+    failed += 1;
+  }
+}
+
+function readPlanCommand() {
+  return fs.readFileSync(planCommandPath, 'utf8');
+}
+
+console.log('\n=== Testing /egc-plan command prompt ===\n');
+
+test('/egc-plan runs inline by default without requiring planner agent', () => {
+  const source = readPlanCommand();
+
+  assert.ok(
+    source.includes('Do not delegate to the `@planner` subagent'),
+    'Expected /egc-plan to avoid default subagent delegation',
+  );
+  assert.ok(
+    source.includes('If the `@planner` subagent is unavailable'),
+    'Expected /egc-plan to define a planner-unavailable fallback',
+  );
+  assert.ok(
+    !source.includes('This command invokes the **planner** agent'),
+    'Expected /egc-plan not to claim unconditional planner invocation',
+  );
+  assert.ok(
+    !source.includes('The planner agent will:'),
+    'Expected /egc-plan to describe inline behavior, not mandatory agent behavior',
+  );
+  assert.ok(
+    !source.includes('Agent (planner):'),
+    'Expected /egc-plan examples not to imply the planner agent is required',
+  );
+});
+
+test('/egc-plan still documents the optional planner agent for manual use', () => {
+  const source = readPlanCommand();
+
+  assert.ok(
+    source.includes('Optional Planner Agent'),
+    'Expected /egc-plan to mention the optional planner agent section',
+  );
+  assert.ok(
+    source.includes('agents/planner.md'),
+    'Expected /egc-plan to reference the planner agent source file',
+  );
+});
+
+test('/egc-plan preserves the WAIT-for-CONFIRM contract', () => {
+  const source = readPlanCommand();
+
+  assert.ok(
+    /\*\*CRITICAL\*\*:.*\*\*NOT\*\* write any code until you explicitly confirm/.test(source),
+    'Expected /egc-plan to retain the explicit-confirm guard',
+  );
+  assert.ok(
+    source.includes('WAITING FOR CONFIRMATION'),
+    'Expected /egc-plan to retain the WAITING FOR CONFIRMATION marker',
+  );
+});
+
+console.log('\n=== Test Results ===');
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+console.log(`Total:  ${passed + failed}\n`);
+
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -21,6 +21,7 @@ const testFiles = [
   'lib/upstream-drift.test.js',
   'hooks/hooks.test.js',
   'hooks/block-no-verify.test.js',
+  'commands/plan-command.test.js',
   'ci/validate-workflow-security.test.js',
   'ci/validate-upstream-sync.test.js',
   'lint/validators.test.js'


### PR DESCRIPTION
## Summary

Third port PR from the 2026-05-12 upstream sync round (audit log: [`upstream/sync-rounds/2026-05-12.md`](https://github.com/Jamkris/everything-gemini-code/blob/main/upstream/sync-rounds/2026-05-12.md)).

Ports ECC [`17aafc4`](https://github.com/affaan-m/everything-claude-code/commit/17aafc45066bdf83771d216fa13433a7b78b18e9) ("fix: make plan command work without planner agent") to EGC's `commands/egc-plan.toml`.

## Why

EGC's previous prompt asserted that `/egc-plan` "invokes the planner agent" unconditionally. When the `@planner` subagent is unavailable — agents not installed, runtime cannot resolve the name, plugin-only install — the assistant surfaces an `Agent type 'planner' not found` error instead of producing a plan. The fix makes the command run inline by default and treat the planner agent as an optional enhancement.

## Changes to the prompt

- Opening paragraph reframes `/egc-plan` as "creates a plan" and explicitly states inline-by-default + no default subagent delegation.
- "How It Works" attributes the steps to "The assistant" instead of "The planner agent".
- Example header changes from `Agent (planner):` to `Assistant:` so the example does not imply the agent is mandatory.
- CRITICAL guard reattributed to "this command" instead of "the planner agent".
- "Related Agents" section renamed to "Optional Planner Agent" with explicit fallback instructions: continue inline if `@planner` is unavailable rather than erroring. Reference to `agents/planner.md` retained for manual installs that ship the agent file.

## New tests (3)

`tests/commands/plan-command.test.js` — adapted from ECC's test of the same name. Reads `commands/egc-plan.toml` and asserts:

- New inline-by-default contract is present (`Do not delegate to the @planner subagent`, planner-unavailable fallback).
- Old mandatory-agent strings are gone (`invokes the **planner** agent`, `The planner agent will:`, `Agent (planner):`).
- The CRITICAL WAIT-for-CONFIRM contract is preserved (regression guard against future rewrites stripping it).

## ECC commit in scope that did not port

- `2fd8dfc` (docs: clarify MCP disable guidance) — entirely Claude Code-specific surface (`~/.claude.json` runtime persistence, the Claude `/mcp` command, `disabledMcpServers` config key, `ECC_DISABLED_MCPS` env var, `.claude/settings.json` paths). EGC's MCP layer is Gemini CLI's `mcp-configs/` model; none of the specific facts in the upstream doc map cleanly. EGC's current guidance ("Disable unused servers in project settings") is already harness-correct at the right altitude.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` 279/279 (+3 new in `commands/plan-command.test.js`)
- [x] `node scripts/ci/validate-commands.js` — 80 command files validated
- [x] Manually re-read the prompt — `/egc-plan` would still produce the same WAITING FOR CONFIRMATION protocol when invoked, just without an upfront `@planner` dispatch


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/egc-plan` work without the `@planner` agent by running inline by default and treating `@planner` as optional. This prevents "Agent type 'planner' not found" errors and keeps planning usable across installs.

- Bug Fixes
  - Updated `commands/egc-plan.toml` to run inline by default, avoid default delegation to `@planner`, and continue inline if `@planner` is unavailable.
  - Reworded prompt to attribute steps to the assistant, updated example header to "Assistant:", and preserved the CRITICAL wait-for-confirmation rule.
  - Added `tests/commands/plan-command.test.js` and registered it in `tests/run-all.js` to enforce the new inline-by-default contract and the confirmation guard.

<sup>Written for commit a3314d902732f0e0ca8126dc23b0831fbfc04461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated `/egc-plan` command to default to inline execution rather than delegating to subagents, with strengthened confirmation prompts before code generation.

* **Tests**
  * Added test coverage to validate `/egc-plan` command behavior and execution flow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jamkris/everything-gemini-code/pull/69)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->