### PR TITLE
docs: sync upstream baseline to e9c88458

### DIFF
--- a/upstream/.upstream-sync.json
+++ b/upstream/.upstream-sync.json
@@ -1,6 +1,6 @@
 {
   "upstream": "affaan-m/everything-claude-code",
-  "lastSyncedSha": "9db98673d054f5ed0991ba9d67ff4c883c81a42f",
-  "lastSyncedAt": "2026-02-09",
-  "notes": "Initial baseline recorded retroactively. EGC's first commit (ff331996) followed this ECC HEAD by 1h13m."
+  "lastSyncedSha": "e9c8845833415204db993a3b0d0bf337fded23da",
+  "lastSyncedAt": "2026-05-13",
+  "notes": "Round 2 sync. Triage and per-commit dispositions: upstream/sync-rounds/2026-05-12.md. The SHA is the last commit *evaluated* — not necessarily the last commit ported. Ports landed: #67 (skill curation), #68 (hooks + validators), #69 (plan command graceful degradation). Skips and architectural mismatches are recorded against the audit log."
 }

--- a/upstream/README.md
+++ b/upstream/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-9db98673-informational)
+![Baseline](https://img.shields.io/badge/baseline-e9c88458-informational)
 
 EGC (Everything Gemini Code) is an **ecosystem port** of [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) by [@affaan-m](https://github.com/affaan-m). It is not an official ECC release and does not claim API or behavioral compatibility with ECC. Harness-specific behavior is verified inside Gemini CLI itself, not by reference to ECC's Claude Code behavior.
 
@@ -15,8 +15,9 @@ This document records how EGC tracks the upstream ECC repository and what was ch
 ## Upstream baseline
 
 - **Upstream repository**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **Last-synced upstream commit**: [`9db98673d054f5ed0991ba9d67ff4c883c81a42f`](https://github.com/affaan-m/everything-claude-code/commit/9db98673d054f5ed0991ba9d67ff4c883c81a42f)
-- **Last-synced date**: 2026-02-09
+- **Last-synced upstream commit**: [`e9c8845833415204db993a3b0d0bf337fded23da`](https://github.com/affaan-m/everything-claude-code/commit/e9c8845833415204db993a3b0d0bf337fded23da)
+- **Last-synced date**: 2026-05-13
+- **Round notes**: see [`sync-rounds/2026-05-12.md`](sync-rounds/2026-05-12.md) for per-commit triage from the 2026-05-12 round. The SHA above is the last commit *evaluated*; not every commit in the focused range was ported.
 - **Initial EGC commit**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 A machine-readable copy of this state lives at [`.upstream-sync.json`](./.upstream-sync.json). A CI validator (`scripts/ci/validate-upstream-sync.js`) asserts that the two files agree on the SHA, so a mismatch blocks the PR automatically.

--- a/upstream/ko-KR/README.md
+++ b/upstream/ko-KR/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-9db98673-informational)
+![Baseline](https://img.shields.io/badge/baseline-e9c88458-informational)
 
 EGC (Everything Gemini Code) 는 [@affaan-m](https://github.com/affaan-m) 의 [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) 를 기반으로 한 **생태계 포트(ecosystem port)** 입니다. ECC의 공식 릴리스가 아니며, ECC와의 API/동작 호환성을 주장하지 않습니다. 하네스 고유 동작은 ECC의 Claude Code 거동을 기준 삼지 않고 Gemini CLI 내부에서 직접 검증합니다.
 
@@ -15,8 +15,9 @@ EGC (Everything Gemini Code) 는 [@affaan-m](https://github.com/affaan-m) 의 [E
 ## 업스트림 베이스라인
 
 - **업스트림 레포지토리**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **마지막 동기화 커밋**: [`9db98673d054f5ed0991ba9d67ff4c883c81a42f`](https://github.com/affaan-m/everything-claude-code/commit/9db98673d054f5ed0991ba9d67ff4c883c81a42f)
-- **마지막 동기화 일자**: 2026-02-09
+- **마지막 동기화 커밋**: [`e9c8845833415204db993a3b0d0bf337fded23da`](https://github.com/affaan-m/everything-claude-code/commit/e9c8845833415204db993a3b0d0bf337fded23da)
+- **마지막 동기화 일자**: 2026-05-13
+- **라운드 노트**: 2026-05-12 라운드의 per-commit 분류는 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md) 참고. 위 SHA는 *평가한* 마지막 커밋이며, 포커스 범위의 모든 커밋이 포팅되지는 않았습니다.
 - **EGC 최초 커밋**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 이 상태의 기계 판독용 사본은 [`.upstream-sync.json`](../.upstream-sync.json) 에 있습니다. CI validator (`scripts/ci/validate-upstream-sync.js`) 가 두 파일의 SHA 일치를 강제하며, 불일치가 발생한 PR은 자동으로 차단됩니다.

--- a/upstream/zh-CN/README.md
+++ b/upstream/zh-CN/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-9db98673-informational)
+![Baseline](https://img.shields.io/badge/baseline-e9c88458-informational)
 
 EGC (Everything Gemini Code) 是 [@affaan-m](https://github.com/affaan-m) 的 [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) 的**生态系统移植版本（ecosystem port）**。它不是 ECC 的官方发行版，也不声称与 ECC 在 API 或行为层面兼容。涉及 harness 自身的行为以 Gemini CLI 内部验证为准，不参照 ECC 在 Claude Code 中的表现。
 
@@ -15,8 +15,9 @@ EGC (Everything Gemini Code) 是 [@affaan-m](https://github.com/affaan-m) 的 [E
 ## 上游基线
 
 - **上游仓库**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **最近一次同步的提交**: [`9db98673d054f5ed0991ba9d67ff4c883c81a42f`](https://github.com/affaan-m/everything-claude-code/commit/9db98673d054f5ed0991ba9d67ff4c883c81a42f)
-- **最近一次同步的日期**: 2026-02-09
+- **最近一次同步的提交**: [`e9c8845833415204db993a3b0d0bf337fded23da`](https://github.com/affaan-m/everything-claude-code/commit/e9c8845833415204db993a3b0d0bf337fded23da)
+- **最近一次同步的日期**: 2026-05-13
+- **回合记录**: 2026-05-12 回合的逐提交分类见 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md)。上面的 SHA 是*评估到*的最后一个提交；并非所有进入焦点范围的提交都被移植。
 - **EGC 的首次提交**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 该状态的机器可读副本位于 [`.upstream-sync.json`](../.upstream-sync.json)。CI 校验器 (`scripts/ci/validate-upstream-sync.js`) 会断言两个文件中的 SHA 一致；不一致的 PR 将被自动阻拦。


### PR DESCRIPTION
## Summary

Final PR of the 2026-05-12 upstream sync round. Advances the recorded baseline from `9db98673` (2026-02-09) to [`e9c88458`](https://github.com/affaan-m/everything-claude-code/commit/e9c8845833415204db993a3b0d0bf337fded23da) (2026-05-11) — the upstream HEAD at triage time and the last commit *evaluated* in this round.

## What landed in this round

- [#66](https://github.com/Jamkris/everything-gemini-code/pull/66) — triage / audit log (`upstream/sync-rounds/2026-05-12.md`)
- [#67](https://github.com/Jamkris/everything-gemini-code/pull/67) — port: skill curation updates from ECC
- [#68](https://github.com/Jamkris/everything-gemini-code/pull/68) — port: hook + validator fixes from ECC (closed two real bypass holes; 3 rounds of bot review)
- [#69](https://github.com/Jamkris/everything-gemini-code/pull/69) — port: plan command graceful degradation

Of the 159 commits in the focused range (4e66b288..e9c88458):

| Disposition | Count |
|---|---|
| Ported | 9 |
| Evaluated inline + skipped | 5 |
| Deferred (eligible net-new skills) | 3 |
| Skipped with rationale | 142 |

The 142 skips are dominated by ECC-runtime-only surfaces (`loop-status`, `gateguard`, `insaits-security-*`, ECC's `cursor`/`codex`/`opencode` install targets, `ecc2` RC1 work) and Claude-Code-specific session-start / observe-runner / MCP-disable changes.

## Files updated (4)

- `upstream/.upstream-sync.json` — `lastSyncedSha` + `lastSyncedAt` + round notes pointing at the audit log.
- `upstream/README.md` — baseline badge, Last-synced commit, date, and a round-notes pointer.
- `upstream/ko-KR/README.md` + `upstream/zh-CN/README.md` — same three updates mirrored.

## Why the baseline is the *evaluated* SHA, not ECC HEAD

ECC has continued to merge commits since triage (~820e07f at the time of this PR). The sync policy explicitly chooses to advance the baseline to **the last commit actually evaluated** rather than the **current upstream HEAD** — see [`upstream/README.md` → Recording a sync](https://github.com/Jamkris/everything-gemini-code/blob/main/upstream/README.md#recording-a-sync). Lying about the SHA would close issue #60 prematurely and hide unevaluated drift.

## Expected post-merge behaviour

- The CI validator (`validate-upstream-sync.js`) passes — the prose SHA and JSON SHA agree on `e9c8845`.
- The next scheduled or manually-dispatched `upstream-drift` workflow run will compute the delta against ECC's current HEAD, find a small drift (only the ~1–2 days of new ECC commits since `e9c88458`), and **update issue #60 with the new (much smaller) count**.
- Issue #60 will not auto-close because ECC continues to merge faster than EGC catches up. That is exactly the "best-effort, surface drift" policy at work — the tracker now shows progress instead of an inflated 1500+ figure.

## Test plan

- [x] `node scripts/ci/validate-upstream-sync.js` — "OK — both files reference e9c8845"
- [x] `npm run lint` — clean
- [x] `npm test` — 279/279
- [x] Manual link check — README baseline → ECC commit, audit log link → `sync-rounds/2026-05-12.md`
- [ ] Post-merge: manually dispatch the upstream-drift workflow and verify issue #60 updates with the new count instead of duplicating to a new issue

## Round end

This PR closes the round. Future rounds will start fresh with a new triage file under `upstream/sync-rounds/`.

Related to / will eventually close [#60](https://github.com/Jamkris/everything-gemini-code/issues/60) once ECC's commit cadence catches down (or, more realistically, the next round).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advances the recorded upstream baseline to e9c88458 (2026-05-11), the last commit evaluated in the 2026-05-12 sync round, and points docs to that round’s audit log. Updates `upstream/.upstream-sync.json`, `upstream/README.md`, `upstream/ko-KR/README.md`, and `upstream/zh-CN/README.md` with the new SHA, date, and notes; the next drift run will recalc against ECC’s current HEAD and shrink the count in issue #60.

<sup>Written for commit b18af8f2da075b02de4ed11595dfc7dcfabc2048. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated upstream synchronization baseline and configuration metadata to reflect the latest evaluated commit.
* Refreshed README documentation in English, Korean, and Chinese languages with current upstream synchronization details and sync date of May 13, 2026.
* Updated internal synchronization tracking notes and references to correspond with the latest round of upstream evaluation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jamkris/everything-gemini-code/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->