### PR TITLE
chore: release v1.3.11

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.10",
+	"version": "1.3.11",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.10",
+	"version": "1.3.11",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.10",
+	"version": "1.3.11",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v1.3.11 release by updating version fields in `.gemini-plugin/plugin.json`, `gemini-extension.json`, and `package.json`. No functional changes.

<sup>Written for commit 5b96bf7c8df91ea6bfb07acfc057bff681ac53cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

