### PR TITLE
docs: record ECC backport in 2026-05-12 sync round log

### DIFF
--- a/upstream/sync-rounds/2026-05-12.md
+++ b/upstream/sync-rounds/2026-05-12.md
@@ -226,3 +226,12 @@ PRs 1–4 can land in parallel. PR 5 must be last.
 
 - The 3 deferred net-new skills (`tinystruct-patterns`, `ios-icon-gen`, `flox-environments`). Open as a separate "ECC net-new skills" round once round 2 lands.
 - The schema split between `lastSyncedSha` and `lastEvaluatedSha` (would change the validator + drift workflow). Defer to its own PR.
+
+## Backports to upstream ECC
+
+While porting `0dcde13` (block-no-verify shell-words rewrite) in PR [#68](https://github.com/Jamkris/everything-gemini-code/pull/68), CodeRabbit's round-3 review surfaced two real bypass holes in the upstream rewrite that EGC inherited verbatim:
+
+- **`core.hooksPath` case-sensitivity bypass** (critical) — `git -c core.hookspath=…` slipped past the guard because the comparison was case-sensitive while Git config keys are case-insensitive.
+- **`-tn` false positive** (major) — `COMMIT_SHORT_OPTIONS_WITH_VALUE` was missing `'t'`, so `git commit -tn templatefile` was falsely blocked as a `-n` (no-verify) bypass.
+
+Both fixes shipped to EGC in [#68](https://github.com/Jamkris/everything-gemini-code/pull/68) (commit `fbf7908`). They were also backported upstream to ECC as [`affaan-m/everything-claude-code#1843`](https://github.com/affaan-m/everything-claude-code/pull/1843) per the dual-PR pattern in `CONTRIBUTING.md`. This is the first contribution flowing the other direction from EGC's sync rounds.


### PR DESCRIPTION
## Summary

Adds a "Backports to upstream ECC" section to [`upstream/sync-rounds/2026-05-12.md`](https://github.com/Jamkris/everything-gemini-code/blob/main/upstream/sync-rounds/2026-05-12.md) recording the two block-no-verify bypass holes that flowed back upstream as [affaan-m/everything-claude-code#1843](https://github.com/affaan-m/everything-claude-code/pull/1843).

## Why

Per the dual-PR pattern in [`CONTRIBUTING.md`](https://github.com/Jamkris/everything-gemini-code/blob/main/CONTRIBUTING.md): when a contribution to EGC is harness-agnostic and would also benefit ECC users, cross-link the two PRs so reviewers on either side can see the upstream/downstream pair. This is the first sync round where work flowed from EGC back to ECC, so the audit log should record it.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` 279/279
- [x] Doc-only change; no source/script modifications

## What ships in the upstream PR (cross-link)

- **core.hooksPath case-sensitivity bypass** — was case-sensitive; \`git -c core.hookspath=…\` slipped past the guard.
- **-tn false positive** — \`COMMIT_SHORT_OPTIONS_WITH_VALUE\` missing \`'t'\` falsely blocked legitimate \`git commit -tn template\`.

Both originally discovered in EGC PR [#68](https://github.com/Jamkris/everything-gemini-code/pull/68) (commit fbf7908) by CodeRabbit's round-3 review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Backports to upstream ECC” section to `upstream/sync-rounds/2026-05-12.md` documenting two block-no-verify bypass fixes and cross-linking the upstream/downstream pair per the dual-PR pattern.

- **Bug Fixes**
  - `core.hooksPath` case-insensitivity bypass: `git -c core.hookspath=…` was not caught.
  - `-tn` false positive: missing `'t'` in short options caused valid `git commit -tn template` to be blocked.

<sup>Written for commit e67c5e1fe7110ef32eadd848e0a4070f1d0684fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated audit log to document security fixes addressing two bypass vulnerabilities.
  * Added backport information detailing fixes shipped to upstream systems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jamkris/everything-gemini-code/pull/73)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->