### PR TITLE
docs: triage ECC upstream commits e9c8845..393d397

### DIFF
--- a/upstream/sync-rounds/2026-05-13.md
+++ b/upstream/sync-rounds/2026-05-13.md
@@ -1,0 +1,114 @@
+# Upstream sync inventory — 2026-05-13
+
+Triage of the ECC drift recorded by [#71](https://github.com/Jamkris/everything-gemini-code/issues/71). The drift tracker reported 65 commits when the issue opened; by triage time ECC `main` had moved to 67 commits ahead of EGC's recorded baseline.
+
+## Range
+
+- **Recorded baseline** in `upstream/.upstream-sync.json`: [`e9c88458`](https://github.com/affaan-m/everything-claude-code/commit/e9c8845833415204db993a3b0d0bf337fded23da) (2026-05-11)
+- **Upstream HEAD at triage time**: [`393d397e`](https://github.com/affaan-m/everything-claude-code/commit/393d397efa40a9e9b6c7296df8181860ebf5047e) (2026-05-12) — `docs: add prompt defense baselines`
+
+**Total drift**: 67 commits.
+
+## Triage method
+
+Same path-based bucketing script used in the 2026-05-12 round. Buckets are mutually exclusive; the first matching rule wins.
+
+Bucket totals:
+
+| Bucket | Count |
+|---|---|
+| A:skills | 1 |
+| A:rules | 0 |
+| A:docs | 30 |
+| B:agents | 2 |
+| C:commands | 0 |
+| E:shared-logic | 6 |
+| F:ci/packaging | 2 |
+| D:other-harness | 8 |
+| H:meta | 1 |
+| X:needs-review | 17 |
+| **Total** | **67** |
+
+## A:skills (1)
+
+| SHA | Subject | Disposition |
+|---|---|---|
+| `cb2a70c` | docs: fix motion skill examples | **skip** — EGC has `remotion-video-creation` but not `motion-advanced`/`motion-foundations`. The new ECC `motion-*` skills are deferred net-new candidates. |
+
+## B:agents (2)
+
+| SHA | Subject | Disposition |
+|---|---|---|
+| `df60af9` | feat: salvage code-reviewer false-positive guardrails (#1817) | **port** — EGC has `agents/code-reviewer.md`. Adds Pre-Report Gate, HIGH/CRITICAL proof requirements, "zero findings is valid" note, a Common False Positives catalog, and an updated Approval Criteria block. All harness-agnostic. |
+| `393d397` | docs: add prompt defense baselines | **port** — Adds a 6-bullet Prompt Defense Baseline block to ECC's `CLAUDE.md` + every agent file. Content is generic prompt-injection defense; will be ported to EGC's `GEMINI.md` and all agents under `agents/`. |
+
+## A:docs (30)
+
+Dominated by ECC 2.0 GA release-tracking work — internal roadmap evidence, harness compliance matrices, salvage ledgers. None applicable to EGC's narrower scope.
+
+Representative skipped subjects: "mirror ECC 2.0 GA roadmap", "record cross repo roadmap evidence", "record AgentShield policy pack evidence", "record ECC Tools taxonomy evidence", "publish stale PR salvage ledger", "inventory workspace legacy repos".
+
+**Round-3 port targets from A:docs**: 0.
+
+## X:needs-review (17)
+
+All 17 fell through the path heuristic because they touched a doc plus a test (`tests/docs/*.test.js`) — same shape as last round's edge cases. Hand-categorized: all ECC 2.0 release surface docs (harness adapter compliance matrix, release publication readiness gate, RC1 publication dry-run evidence, etc.). **All skip.**
+
+## C:commands (0)
+
+No upstream command changes in the focused range.
+
+## E:shared-logic (6) — wholesale skip
+
+ECC-only infrastructure: ECC statusline observability hooks, MCP stderr probe stabilization, InsAIts wrapper Python shim, harness adapter scorecard, HUD status control contract, workflow install boundaries. EGC has no analogues.
+
+## F:ci/packaging (2) — wholesale skip
+
+Dependabot / CI tweaks specific to ECC's release workflow.
+
+## D:other-harness (8) — deferred (net-new features)
+
+ECC added meaningful new feature surfaces this round, but they are bigger than a sync-round port:
+
+- `f8070dd` — PRD planning command flow
+- `e17f2bc` — network architect agents
+- `f219a90` — motion system skills (motion-advanced, motion-foundations)
+- `f03e200` — Quarkus handling
+- `f239379` — Django Celery workflow (#1812)
+- `65c1502` — cost tracking and skill scout (#1815)
+- `ab0f018` — frontend design guidance (#1816)
+- `71ed7c5` — homelab config skills (VLAN, Pi-hole, WireGuard) (#1838)
+
+These are eligible for a future "ECC net-new" round (same pattern as the deferred `tinystruct-patterns`, `ios-icon-gen`, `flox-environments` from round 2). Not in scope here.
+
+## H:meta (1)
+
+| SHA | Subject | Disposition |
+|---|---|---|
+| `7f3dfde` | chore: bump rand lockfile advisory (#1837) | **skip** — ECC release lockfile chore |
+
+## Summary
+
+| Category | Port now | Defer (net-new, bigger scope) | Skip |
+|---|---|---|---|
+| A:skills | 0 | — | 1 |
+| A:rules | 0 | — | 0 |
+| A:docs | 0 | — | 30 |
+| B:agents | 2 | — | 0 |
+| C:commands | 0 | — | 0 |
+| E:shared-logic | 0 | — | 6 |
+| F:ci/packaging | 0 | — | 2 |
+| D:other-harness | 0 | 8 | 0 |
+| H:meta | 0 | — | 1 |
+| X:needs-review | 0 | — | 17 |
+| **Total** | **2** | **8** | **57** |
+
+## Follow-up PRs (in suggested order)
+
+1. **`port: code-reviewer guardrails + prompt defense baselines from ECC`** — covers `df60af9` and `393d397`. Touches `agents/code-reviewer.md`, `GEMINI.md`, and the full `agents/` tree (uniform 6-bullet block prepended after frontmatter).
+2. **`docs: sync upstream baseline to 393d397`** — updates `upstream/.upstream-sync.json` + `upstream/README.md` (+ ko-KR / zh-CN mirrors). Closes [#71](https://github.com/Jamkris/everything-gemini-code/issues/71) automatically when the drift workflow next runs.
+
+## Out of scope for this round
+
+- The 8 deferred D:other-harness net-new features (PRD command, network architect agents, motion system skills, Quarkus, Django Celery, cost tracking, frontend design, homelab configs). Open as a separate round-N "ECC net-new" PR set.
+- The 3 deferred net-new skills carried over from round 2 (`tinystruct-patterns`, `ios-icon-gen`, `flox-environments`). Still out of scope.


### PR DESCRIPTION
## Summary

Round 3 audit log. ECC moved 67 commits forward of the baseline recorded at the end of round 2 ([#71](https://github.com/Jamkris/everything-gemini-code/issues/71) reported 65 when the drift tracker opened; ECC merged 2 more before triage).

## Round 3 totals

| Category | Port now | Defer (net-new) | Skip |
|---|---|---|---|
| skills | 0 | — | 1 |
| docs | 0 | — | 30 |
| agents | 2 | — | 0 |
| commands | 0 | — | 0 |
| shared logic | 0 | — | 6 |
| CI / packaging | 0 | — | 2 |
| other-harness (net-new features) | 0 | 8 | 0 |
| meta | 0 | — | 1 |
| needs-review (edge cases) | 0 | — | 17 |
| **Total** | **2** | **8** | **57** |

## Notable findings

- `df60af9` (code-reviewer guardrails) — adds Pre-Report Gate, HIGH/CRITICAL proof rules, "zero findings is valid" guidance, and a Common False Positives catalog to ECC's code-reviewer agent. All harness-agnostic. Port target.
- `393d397` (prompt defense baselines) — adds a uniform 6-bullet prompt-defense block to ECC's `CLAUDE.md` and every agent file (71 files total upstream). Port target — apply to EGC's `GEMINI.md` and all agents.

## Deferred (8 net-new features)

ECC added meaningful new surfaces this round that exceed a sync-round port scope: PRD planning command, network architect agents, motion system skills, Quarkus handling, Django Celery workflow, cost tracking + skill scout, frontend design guidance, homelab config skills. These join the deferred net-new candidates from round 2 (`tinystruct-patterns`, `ios-icon-gen`, `flox-environments`) — should be opened as a dedicated "ECC net-new" PR set in a future round.

## Follow-up PRs

1. \`port: code-reviewer guardrails + prompt defense baselines from ECC\`
2. \`docs: sync upstream baseline to 393d397\` — closes [#71](https://github.com/Jamkris/everything-gemini-code/issues/71)

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` 279/279
- [x] Doc-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the 2026-05-13 upstream sync inventory documenting ECC drift (67 commits from `e9c8845` to `393d397`). It calls out two port targets (code-reviewer guardrails and prompt-defense baselines), defers eight net-new features, and marks 57 skips to guide follow-ups.

<sup>Written for commit 925b1c8e371e9b30db2ad25f2acc6a323e78f47f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the 2026-05-13 upstream sync round, including triage inventory results across multiple categories, summary statistics, and suggested follow-up actions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jamkris/everything-gemini-code/pull/74)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->