### PR TITLE
docs: sync upstream baseline to 393d397

### DIFF
--- a/upstream/.upstream-sync.json
+++ b/upstream/.upstream-sync.json
@@ -1,6 +1,6 @@
 {
   "upstream": "affaan-m/everything-claude-code",
-  "lastSyncedSha": "e9c8845833415204db993a3b0d0bf337fded23da",
+  "lastSyncedSha": "393d397efa40a9e9b6c7296df8181860ebf5047e",
   "lastSyncedAt": "2026-05-13",
-  "notes": "Round 2 sync. Triage and per-commit dispositions: upstream/sync-rounds/2026-05-12.md. The SHA is the last commit *evaluated* — not necessarily the last commit ported. Ports landed: #67 (skill curation), #68 (hooks + validators), #69 (plan command graceful degradation). Skips and architectural mismatches are recorded against the audit log."
+  "notes": "Round 3 sync. Triage and per-commit dispositions: upstream/sync-rounds/2026-05-13.md. The SHA is the last commit *evaluated* — not necessarily the last commit ported. Ports landed: #75 (code-reviewer guardrails + prompt defense baselines). Net-new ECC features (PRD command, network architect agents, motion skills, Quarkus, Django Celery, cost tracking, frontend design, homelab configs) deferred to a future net-new round."
 }

--- a/upstream/README.md
+++ b/upstream/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-e9c88458-informational)
+![Baseline](https://img.shields.io/badge/baseline-393d397e-informational)
 
 EGC (Everything Gemini Code) is an **ecosystem port** of [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) by [@affaan-m](https://github.com/affaan-m). It is not an official ECC release and does not claim API or behavioral compatibility with ECC. Harness-specific behavior is verified inside Gemini CLI itself, not by reference to ECC's Claude Code behavior.
 
@@ -15,9 +15,9 @@ This document records how EGC tracks the upstream ECC repository and what was ch
 ## Upstream baseline
 
 - **Upstream repository**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **Last-synced upstream commit**: [`e9c8845833415204db993a3b0d0bf337fded23da`](https://github.com/affaan-m/everything-claude-code/commit/e9c8845833415204db993a3b0d0bf337fded23da)
+- **Last-synced upstream commit**: [`393d397efa40a9e9b6c7296df8181860ebf5047e`](https://github.com/affaan-m/everything-claude-code/commit/393d397efa40a9e9b6c7296df8181860ebf5047e)
 - **Last-synced date**: 2026-05-13
-- **Round notes**: see [`sync-rounds/2026-05-12.md`](sync-rounds/2026-05-12.md) for per-commit triage from the 2026-05-12 round. The SHA above is the last commit *evaluated*; not every commit in the focused range was ported.
+- **Round notes**: see [`sync-rounds/2026-05-13.md`](sync-rounds/2026-05-13.md) for the latest round; [`sync-rounds/2026-05-12.md`](sync-rounds/2026-05-12.md) for the first triage. The SHA above is the last commit *evaluated*; not every commit in the focused range was ported.
 - **Initial EGC commit**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 A machine-readable copy of this state lives at [`.upstream-sync.json`](./.upstream-sync.json). A CI validator (`scripts/ci/validate-upstream-sync.js`) asserts that the two files agree on the SHA, so a mismatch blocks the PR automatically.

--- a/upstream/ko-KR/README.md
+++ b/upstream/ko-KR/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-e9c88458-informational)
+![Baseline](https://img.shields.io/badge/baseline-393d397e-informational)
 
 EGC (Everything Gemini Code) 는 [@affaan-m](https://github.com/affaan-m) 의 [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) 를 기반으로 한 **생태계 포트(ecosystem port)** 입니다. ECC의 공식 릴리스가 아니며, ECC와의 API/동작 호환성을 주장하지 않습니다. 하네스 고유 동작은 ECC의 Claude Code 거동을 기준 삼지 않고 Gemini CLI 내부에서 직접 검증합니다.
 
@@ -15,9 +15,9 @@ EGC (Everything Gemini Code) 는 [@affaan-m](https://github.com/affaan-m) 의 [E
 ## 업스트림 베이스라인
 
 - **업스트림 레포지토리**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **마지막 동기화 커밋**: [`e9c8845833415204db993a3b0d0bf337fded23da`](https://github.com/affaan-m/everything-claude-code/commit/e9c8845833415204db993a3b0d0bf337fded23da)
+- **마지막 동기화 커밋**: [`393d397efa40a9e9b6c7296df8181860ebf5047e`](https://github.com/affaan-m/everything-claude-code/commit/393d397efa40a9e9b6c7296df8181860ebf5047e)
 - **마지막 동기화 일자**: 2026-05-13
-- **라운드 노트**: 2026-05-12 라운드의 per-commit 분류는 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md) 참고. 위 SHA는 *평가한* 마지막 커밋이며, 포커스 범위의 모든 커밋이 포팅되지는 않았습니다.
+- **라운드 노트**: 최신 라운드는 [`sync-rounds/2026-05-13.md`](../sync-rounds/2026-05-13.md), 첫 triage는 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md) 참고. 위 SHA는 *평가한* 마지막 커밋이며, 포커스 범위의 모든 커밋이 포팅되지는 않았습니다.
 - **EGC 최초 커밋**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 이 상태의 기계 판독용 사본은 [`.upstream-sync.json`](../.upstream-sync.json) 에 있습니다. CI validator (`scripts/ci/validate-upstream-sync.js`) 가 두 파일의 SHA 일치를 강제하며, 불일치가 발생한 PR은 자동으로 차단됩니다.

--- a/upstream/zh-CN/README.md
+++ b/upstream/zh-CN/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-e9c88458-informational)
+![Baseline](https://img.shields.io/badge/baseline-393d397e-informational)
 
 EGC (Everything Gemini Code) 是 [@affaan-m](https://github.com/affaan-m) 的 [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) 的**生态系统移植版本（ecosystem port）**。它不是 ECC 的官方发行版，也不声称与 ECC 在 API 或行为层面兼容。涉及 harness 自身的行为以 Gemini CLI 内部验证为准，不参照 ECC 在 Claude Code 中的表现。
 
@@ -15,9 +15,9 @@ EGC (Everything Gemini Code) 是 [@affaan-m](https://github.com/affaan-m) 的 [E
 ## 上游基线
 
 - **上游仓库**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **最近一次同步的提交**: [`e9c8845833415204db993a3b0d0bf337fded23da`](https://github.com/affaan-m/everything-claude-code/commit/e9c8845833415204db993a3b0d0bf337fded23da)
+- **最近一次同步的提交**: [`393d397efa40a9e9b6c7296df8181860ebf5047e`](https://github.com/affaan-m/everything-claude-code/commit/393d397efa40a9e9b6c7296df8181860ebf5047e)
 - **最近一次同步的日期**: 2026-05-13
-- **回合记录**: 2026-05-12 回合的逐提交分类见 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md)。上面的 SHA 是*评估到*的最后一个提交；并非所有进入焦点范围的提交都被移植。
+- **回合记录**: 最新回合见 [`sync-rounds/2026-05-13.md`](../sync-rounds/2026-05-13.md)，首次 triage 见 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md)。上面的 SHA 是*评估到*的最后一个提交；并非所有进入焦点范围的提交都被移植。
 - **EGC 的首次提交**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 该状态的机器可读副本位于 [`.upstream-sync.json`](../.upstream-sync.json)。CI 校验器 (`scripts/ci/validate-upstream-sync.js`) 会断言两个文件中的 SHA 一致；不一致的 PR 将被自动阻拦。


### PR DESCRIPTION
## Summary

Final PR of the 2026-05-13 upstream sync round. Advances the recorded baseline from `e9c88458` (2026-05-11) to [`393d397`](https://github.com/affaan-m/everything-claude-code/commit/393d397efa40a9e9b6c7296df8181860ebf5047e) (2026-05-12) — the upstream HEAD at triage time and the last commit *evaluated* this round.

## Round 3 PRs

- [#74](https://github.com/Jamkris/everything-gemini-code/pull/74) — triage / audit log (`upstream/sync-rounds/2026-05-13.md`)
- [#75](https://github.com/Jamkris/everything-gemini-code/pull/75) — port: code-reviewer guardrails + prompt defense baselines

Of 67 commits in the focused range: **2 ported, 8 deferred** (net-new feature additions: PRD command, network architect agents, motion skills, Quarkus, Django Celery, cost tracking, frontend design, homelab configs), **57 skipped** with rationale.

## Files updated (4)

- `upstream/.upstream-sync.json` — `lastSyncedSha` + `lastSyncedAt` + round notes pointing at the new audit log.
- `upstream/README.md` — baseline badge, Last-synced commit, date, round-notes pointer (now references both 2026-05-13 and 2026-05-12).
- `upstream/ko-KR/README.md` + `upstream/zh-CN/README.md` — mirrored.

## Expected post-merge behaviour

- The validator passes — the prose SHA and JSON SHA agree on `393d397`.
- Next scheduled or manually-dispatched `upstream-drift` workflow run will compute the delta against ECC's current HEAD. If ECC has moved past `393d397` (likely — they merge daily), issue [#71](https://github.com/Jamkris/everything-gemini-code/issues/71) updates with the new (small) count. If no new ECC commits since `393d397`, [#71](https://github.com/Jamkris/everything-gemini-code/issues/71) auto-closes.

## Test plan

- [x] `node scripts/ci/validate-upstream-sync.js` — "OK — both files reference 393d397"
- [x] `npm run lint` clean
- [x] `npm test` 279/279
- [x] Manual link check — README baseline → ECC commit, audit log links → 2026-05-13.md + 2026-05-12.md

## Round end

This PR closes round 3.

Related to [#71](https://github.com/Jamkris/everything-gemini-code/issues/71).
