### PR TITLE
chore: release v1.3.12

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.11",
+	"version": "1.3.12",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.11",
+	"version": "1.3.12",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.11",
+	"version": "1.3.12",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare release v1.3.12 by aligning version fields across manifests. Updated `package.json`, `.gemini-plugin/plugin.json`, and `gemini-extension.json` to 1.3.12.

<sup>Written for commit 9607d5146c280f4f057e9574c86873ebda2b0b46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

