### PR TITLE
docs: redesign README header for first-5-seconds hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,116 +8,95 @@
 
 [![Stars](https://img.shields.io/github/stars/Jamkris/everything-gemini-code?style=flat)](https://github.com/Jamkris/everything-gemini-code/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![Skills](https://img.shields.io/badge/skills-183-green)
+![Agents](https://img.shields.io/badge/agents-48-purple)
+![Commands](https://img.shields.io/badge/commands-80-blue)
 
-**A comprehensive configuration suite for Gemini CLI / Antigravity.**
+**Battle-tested agents, skills, and workflows for Gemini CLI / Antigravity.**
 
-This extension provides production-ready agents, skills, hooks, commands, rules, and MCP configurations designed to supercharge your development workflow with Gemini.
+Ports 183 skills and 48 agents from [Everything Claude Code](https://github.com/affaan-m/everything-claude-code), retuned for Gemini's tool model. Adds Gemini-native features like `/egc-grok` — a whole-repo audit that uses Gemini's 1M context window in a single pass (Claude Code's 200K can't).
 
 ---
 
-## 🚀 Quick Start
+## What you can do
 
-npm install -g @google/gemini-cli@latest
+- **Audit your whole repo in one pass** — `/egc-grok` uses Gemini's 1M context to map architecture, find dead files, detect circular deps. No file-by-file scrolling.
+- **Plan-before-code workflow** — `@planner` returns a phased breakdown with risks and dependencies. WAITs for your confirm before writing anything.
+- **Test-driven feature flow** — `/egc-tdd` + `@tdd-guide` enforce write-tests-first with 80%+ coverage.
+- **Security review on demand** — `@security-reviewer` flags OWASP top 10, hardcoded secrets, injection risks before commit.
+- **183 skills, on-demand** — Clean Architecture, MCP, Remotion, Django, x402 payments, and more. Loaded only when referenced.
 
-````
+---
 
-### Authentication (Required)
-
-The Gemini CLI requires an API key to function.
-
-1.  Get your API key from [Google AI Studio](https://aistudio.google.com/).
-2.  Set it as an environment variable:
-
-```bash
-export GEMINI_API_KEY="your_api_key_here"
-````
-
-Or configure it using the CLI (if supported by your version):
-
-```bash
-gemini config set apiKey "your_api_key_here"
-```
-
-### Option 1: Install via Gemini CLI (Recommended)
-
-The easiest way to install. This will automatically set up the extension for Gemini CLI.
+## Quick Start
 
 ```bash
 gemini extensions install https://github.com/Jamkris/everything-gemini-code
 ```
 
-### Option 2: Install via Script (For Antigravity & Advanced Users)
+That's it. No clone, no symlinks. Requires `GEMINI_API_KEY` in your environment ([get one from Google AI Studio](https://aistudio.google.com/)):
+
+```bash
+export GEMINI_API_KEY="your_api_key_here"
+```
+
+<details>
+<summary><strong>Other install methods (Antigravity, manual, dev mode, uninstall)</strong></summary>
+
+### Install via Script (Antigravity / advanced)
 
 Recommended if you use **Antigravity** (VS Code / Cursor) or need to customize the installation. Existing configurations will be updated.
 
 ```bash
-# Install for Antigravity (Recommended)
+# Antigravity only
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/install.sh)" -- --antigravity
 
-# Install All (CLI + Antigravity)
+# CLI + Antigravity
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/install.sh)" -- --all
 ```
 
-### Option 1: Uninstallation (Recommended)
+### Manual installation
 
 ```bash
-gemini extensions uninstall https://github.com/Jamkris/everything-gemini-code
+git clone https://github.com/Jamkris/everything-gemini-code.git
+
+# Copy agents, commands, skills
+cp everything-gemini-code/agents/*.md ~/.gemini/agents/
+cp everything-gemini-code/commands/*.toml ~/.gemini/commands/
+cp -r everything-gemini-code/skills/* ~/.gemini/skills/
+
+# Antigravity workflows (optional)
+cp everything-gemini-code/workflows/*.md ~/.gemini/antigravity/global_workflows/
 ```
 
-### Option 2: Uninstallation (Manual Script)
+> **For Antigravity users:** copying to `~/.gemini/antigravity/` subdirectories (`global_agents`, `global_skills`) is recommended for full compatibility. `install.sh` handles this automatically.
+>
+> **Rules:** Bundled into `~/.gemini/GEMINI.md` by `install.sh`. For manual installs, copy a template: `cp everything-gemini-code/templates/GEMINI_GLOBAL.md ~/.gemini/GEMINI.md`
+
+### Developer mode (link instead of copy)
+
+For developing or contributing to this extension:
 
 ```bash
-# Selective Uninstall (Recommended): Removes only files installed by this extension.
+git clone https://github.com/Jamkris/everything-gemini-code.git
+cd everything-gemini-code
+gemini extensions link .
+```
+
+### Uninstall
+
+```bash
+# Extension install
+gemini extensions uninstall https://github.com/Jamkris/everything-gemini-code
+
+# Script-based install (selective — only files installed by this extension)
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/uninstall.sh)" -- --antigravity
 
-# Full Uninstall (Caution): Deletes ALL files in the target directories.
+# Script-based install (full — deletes everything in the target dirs)
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/uninstall.sh)" -- --antigravity --purge
 ```
 
-### Option 2: Manual Installation (Advanced)
-
-If you prefer manual control or need to customize specific components:
-
-```bash
-# Clone the repository
-git clone https://github.com/Jamkris/everything-gemini-code.git
-
-# Copy agents
-cp everything-gemini-code/agents/*.md ~/.gemini/agents/
-
-# Copy commands (Gemini CLI)
-cp everything-gemini-code/commands/*.toml ~/.gemini/commands/
-
-# Copy workflows (Antigravity)
-# Note: For Antigravity, use ~/.gemini/antigravity/global_workflows/
-cp everything-gemini-code/workflows/*.md ~/.gemini/antigravity/global_workflows/
-
-# Copy skills
-cp -r everything-gemini-code/skills/* ~/.gemini/skills/
-
-```
-
-> **For Antigravity Users:**
-> If you are manually installing for Antigravity, copying to `~/.gemini/antigravity/` subdirectories (`global_agents`, `global_skills`) is recommended for full compatibility. The `install.sh` script handles this automatically.
->
-> **Note:** Rules are bundled into `~/.gemini/GEMINI.md` via `install.sh`. For manual installs, copy a template: `cp everything-gemini-code/templates/GEMINI_GLOBAL.md ~/.gemini/GEMINI.md`
-
-````
-
-### Option 3: Install as Gemini CLI Extension (Developer Mode)
-
-You can link this repository directly to Gemini CLI as an extension. This allows you to develop and test changes in real-time.
-
-```bash
-# Clone the repository
-git clone https://github.com/Jamkris/everything-gemini-code.git
-cd everything-gemini-code
-
-# Link the extension
-gemini extensions link .
-````
-
-> ⚠️ **Note:** Rules are generated into `~/.gemini/GEMINI.md` by the install script. For extension-only installs, copy a template manually: `cp templates/GEMINI_GLOBAL.md ~/.gemini/GEMINI.md`
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Recommended if you use **Antigravity** (VS Code / Cursor) or need to customize t
 
 ```bash
 # Antigravity only
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/install.sh)" -- --antigravity
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/install.sh)" -- --antigravity
 
 # CLI + Antigravity
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/install.sh)" -- --all
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/install.sh)" -- --all
 ```
 
 ### Manual installation
@@ -89,12 +89,17 @@ gemini extensions link .
 # Extension install
 gemini extensions uninstall https://github.com/Jamkris/everything-gemini-code
 
-# Script-based install (selective — only files installed by this extension)
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/uninstall.sh)" -- --antigravity
+# Script-based install (Antigravity only — selective)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/uninstall.sh)" -- --antigravity
 
-# Script-based install (full — deletes everything in the target dirs)
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/uninstall.sh)" -- --antigravity --purge
+# Script-based install (CLI + Antigravity — selective)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/uninstall.sh)" -- --all
+
+# Script-based install (Antigravity, full — deletes everything in target dirs)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/uninstall.sh)" -- --antigravity --purge
 ```
+
+> **Why the pinned tag?** `curl | bash` from a moving branch is reproducibility- and supply-chain-unsafe. The URLs above point at the `v1.3.12` release tag. To check what's running, view the script at <https://github.com/Jamkris/everything-gemini-code/blob/v1.3.12/scripts/install.sh> before executing.
 
 </details>
 

--- a/docs/ko-KR/README.md
+++ b/docs/ko-KR/README.md
@@ -8,54 +8,80 @@
 
 [![Stars](https://img.shields.io/github/stars/Jamkris/everything-gemini-code?style=flat)](https://github.com/Jamkris/everything-gemini-code/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+![Skills](https://img.shields.io/badge/skills-183-green)
+![Agents](https://img.shields.io/badge/agents-48-purple)
+![Commands](https://img.shields.io/badge/commands-80-blue)
 ![Shell](https://img.shields.io/badge/-Shell-4EAA25?logo=gnu-bash&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?logo=typescript&logoColor=white)
 ![Python](https://img.shields.io/badge/-Python-3776AB?logo=python&logoColor=white)
 ![Go](https://img.shields.io/badge/-Go-00ADD8?logo=go&logoColor=white)
 
-**Gemini CLI / Antigravity를 위한 종합 설정 및 에이전트 시스템.**
+**Gemini CLI / Antigravity 를 위한 검증된 에이전트, 스킬, 워크플로우 모음.**
 
-단순한 설정 파일 모음이 아닙니다. 에이전트, 스킬, 훅, 커맨드, 룰, MCP 설정을 아우르는 완전한 시스템입니다.
-실제 프로덕트를 만들며 매일 집중적으로 사용해 발전시킨 프로덕션 레벨의 설정이 포함되어 있습니다.
-
-**Gemini CLI**, **Antigravity** 등 다양한 AI 에이전트 환경에서 사용할 수 있습니다.
+[Everything Claude Code](https://github.com/affaan-m/everything-claude-code)에서 183개 스킬과 48개 에이전트를 Gemini 의 툴 모델로 포팅했습니다. `/egc-grok` 같은 Gemini 전용 기능도 추가되어 있어요 — Gemini 의 1M 컨텍스트로 레포 전체를 한 번에 감사하는 명령어입니다 (Claude Code 의 200K 로는 불가능한 영역).
 
 ---
 
-## 🚀 빠른 시작
+## 무엇을 할 수 있나
 
-### 1단계: Gemini CLI 설치
+- **레포 전체를 한 번에 감사** — `/egc-grok` 이 Gemini 의 1M 컨텍스트로 아키텍처 맵, 데드 파일, 순환 의존을 한 번에 추출합니다. 파일별 스크롤 불필요.
+- **계획-먼저 워크플로우** — `@planner` 가 단계별 분해 + 리스크 + 의존성을 반환하고, 코드 작성 전에 사용자의 확인을 기다립니다.
+- **테스트-우선 흐름** — `/egc-tdd` + `@tdd-guide` 가 테스트 먼저 + 80% 이상 커버리지를 강제합니다.
+- **온디맨드 보안 리뷰** — `@security-reviewer` 가 OWASP Top 10, 하드코딩된 시크릿, 인젝션 위험을 커밋 전에 표시합니다.
+- **183개 스킬, 필요할 때만** — Clean Architecture, MCP, Remotion, Django, x402 결제 등. 참조될 때만 로드됩니다.
 
-```bash
-npm install -g @google/gemini-cli@latest
-```
+---
 
-### 2단계: API 키 설정
-
-1. [Google AI Studio](https://aistudio.google.com/)에서 API 키를 발급받으세요.
-2. 환경 변수로 설정하세요:
-
-```bash
-export GEMINI_API_KEY="your_api_key_here"
-```
-
-### 3단계: 확장 설치 (권장)
+## 빠른 시작
 
 ```bash
 gemini extensions install https://github.com/Jamkris/everything-gemini-code
 ```
 
-Antigravity 사용자는 스크립트를 사용하세요:
+끝. 클론도 심볼릭링크도 필요 없습니다. 환경 변수에 `GEMINI_API_KEY` 만 있으면 됩니다 ([Google AI Studio 에서 발급](https://aistudio.google.com/)):
 
 ```bash
-# Antigravity용 설치
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/install.sh)" -- --antigravity
-
-# CLI + Antigravity 모두 설치
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/install.sh)" -- --all
+export GEMINI_API_KEY="your_api_key_here"
 ```
 
-### 4단계: 사용 시작
+<details>
+<summary><strong>다른 설치 방법 (Antigravity / 수동 / 개발 모드 / 제거)</strong></summary>
+
+### 스크립트로 설치 (Antigravity / 고급)
+
+**Antigravity** (VS Code / Cursor) 를 쓰거나 설치를 커스터마이즈해야 한다면 권장됩니다. 기존 설정은 갱신됩니다.
+
+```bash
+# Antigravity 만
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/install.sh)" -- --antigravity
+
+# CLI + Antigravity
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/install.sh)" -- --all
+```
+
+### 제거
+
+```bash
+# 익스텐션 설치
+gemini extensions uninstall https://github.com/Jamkris/everything-gemini-code
+
+# 스크립트 설치 (Antigravity 만, 선택적)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/uninstall.sh)" -- --antigravity
+
+# 스크립트 설치 (CLI + Antigravity, 선택적)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/uninstall.sh)" -- --all
+
+# 스크립트 설치 (Antigravity, 풀 — 타깃 디렉토리 전체 삭제)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/uninstall.sh)" -- --antigravity --purge
+```
+
+> **왜 태그를 핀하나요?** 움직이는 브랜치를 향해 `curl | bash` 하는 건 재현성과 공급망 안전성 측면에서 위험합니다. 위 URL 들은 `v1.3.12` 릴리스 태그를 가리킵니다. 실제로 무엇이 실행되는지 확인하려면 <https://github.com/Jamkris/everything-gemini-code/blob/v1.3.12/scripts/install.sh> 를 먼저 보세요.
+
+</details>
+
+### 첫 명령어
+
+설치 후 Gemini CLI 에서:
 
 ```bash
 # 기능 구현 계획
@@ -64,20 +90,15 @@ Antigravity 사용자는 스크립트를 사용하세요:
 # TDD 워크플로우 시작
 /egc-tdd "사용자 서비스 생성"
 
-# 코드 리뷰 실행
-/egc-code-review
+# 레포 전체 감사
+/egc-grok
 
 # 에이전트 직접 호출
 @architect "마이크로서비스 아키텍처 설계"
 @security-reviewer "이 파일의 인젝션 취약점 감사"
 ```
 
-> **Antigravity 사용자 참고:** 워크플로우는 bare name 으로 설치됩니다
-> (예: `/tdd`, `/code-review`, `/build-fix`). Antigravity 내장 `/plan` 과
-> 충돌하는 `/egc-plan` 에만 `egc-` 프리픽스가 붙습니다. Gemini CLI 에서는
-> 내장 커맨드 충돌 방지를 위해 모든 커맨드가 `egc-` 프리픽스를 사용합니다.
-
-✨ **완료!** 이제 28개 에이전트, 125개 스킬, 60개 커맨드를 사용할 수 있습니다.
+> **Antigravity 사용자 참고:** 워크플로우는 bare name 으로 설치됩니다 (예: `/tdd`, `/code-review`, `/build-fix`). Antigravity 내장 `/plan` 과 충돌하는 `/egc-plan` 에만 `egc-` 프리픽스가 붙습니다. Gemini CLI 에서는 내장 커맨드 충돌 방지를 위해 모든 커맨드가 `egc-` 프리픽스를 사용합니다.
 
 ---
 
@@ -89,7 +110,7 @@ Antigravity 사용자는 스크립트를 사용하세요:
 everything-gemini-code/
 ├── gemini-extension.json  # 확장 매니페스트
 │
-├── agents/                # 전문 서브에이전트 (28개)
+├── agents/                # 전문 서브에이전트 (48개)
 │   ├── planner.md           # 기능 구현 계획
 │   ├── architect.md         # 시스템 설계 의사결정
 │   ├── tdd-guide.md         # 테스트 주도 개발
@@ -118,7 +139,7 @@ everything-gemini-code/
 │   ├── rust-build-resolver.md  # Rust 빌드 에러 해결
 │   └── pytorch-build-resolver.md # PyTorch/CUDA 훈련 에러
 │
-├── skills/                # 워크플로우 정의 및 도메인 지식 (125개)
+├── skills/                # 워크플로우 정의 및 도메인 지식 (183개)
 │   ├── coding-standards/          # 언어 모범 사례
 │   ├── backend-patterns/          # API, 데이터베이스, 캐싱 패턴
 │   ├── frontend-patterns/         # React, Next.js 패턴
@@ -147,7 +168,7 @@ everything-gemini-code/
 │   ├── search-first/              # 리서치-먼저 개발 워크플로우
 │   └── 그 외 100개+ 스킬...
 │
-├── commands/              # Gemini CLI 커맨드 (.toml, 60개)
+├── commands/              # Gemini CLI 커맨드 (.toml, 80개)
 │   ├── plan.toml            # /egc-plan - 구현 계획
 │   ├── tdd.toml             # /egc-tdd - 테스트 주도 개발
 │   ├── code-review.toml     # /egc-code-review - 코드 리뷰

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -8,58 +8,89 @@
 
 [![Stars](https://img.shields.io/github/stars/Jamkris/everything-gemini-code?style=flat)](https://github.com/Jamkris/everything-gemini-code/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![Skills](https://img.shields.io/badge/skills-183-green)
+![Agents](https://img.shields.io/badge/agents-48-purple)
+![Commands](https://img.shields.io/badge/commands-80-blue)
 
-**适用于 Gemini CLI / Antigravity 的综合配置套件。**
+**适用于 Gemini CLI / Antigravity 的经过实战检验的 Agents、Skills 和 Workflows。**
 
-该扩展提供了生产级的 Agents、Skills、Hooks、Commands、Rules 和 MCP 配置，旨在通过 Gemini 极大地增强您的开发工作流。
+从 [Everything Claude Code](https://github.com/affaan-m/everything-claude-code) 移植了 183 个 Skills 和 48 个 Agents，并针对 Gemini 的工具模型重新调整。新增了 `/egc-grok` 等 Gemini 原生功能 —— 使用 Gemini 的 1M 上下文窗口一次性审计整个仓库（Claude Code 的 200K 上下文做不到）。
 
 ---
 
-## 🚀 快速开始
+## 你能做什么
 
-### 选项 1：通过 Gemini CLI 安装（推荐）
+- **一次性审计整个仓库** — `/egc-grok` 利用 Gemini 的 1M 上下文绘制架构图、查找死文件、检测循环依赖。无需逐文件翻阅。
+- **先规划后编码** — `@planner` 返回带风险和依赖的分阶段方案，在写代码前等待你的确认。
+- **测试驱动流程** — `/egc-tdd` + `@tdd-guide` 强制先写测试 + 80% 以上覆盖率。
+- **按需安全审查** — `@security-reviewer` 在提交前标记 OWASP Top 10、硬编码 secrets、注入风险。
+- **183 个 Skills，按需加载** — Clean Architecture、MCP、Remotion、Django、x402 支付等。仅在被引用时加载。
+
+---
+
+## 快速开始
 
 ```bash
-# 直接从 GitHub 安装
 gemini extensions install https://github.com/Jamkris/everything-gemini-code
 ```
 
-### 选项 2：手动安装（高级）
-
-如果您偏好手动控制或需要自定义特定组件：
+就这些。无需 clone、无需软链。只需环境变量中有 `GEMINI_API_KEY`（[从 Google AI Studio 获取](https://aistudio.google.com/)）：
 
 ```bash
-# 克隆仓库
+export GEMINI_API_KEY="your_api_key_here"
+```
+
+<details>
+<summary><strong>其他安装方式（Antigravity / 手动 / 开发模式 / 卸载）</strong></summary>
+
+### 脚本安装（Antigravity / 高级）
+
+如果您使用 **Antigravity**（VS Code / Cursor）或需要自定义安装，推荐此方式。会更新现有配置。
+
+```bash
+# 仅 Antigravity
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/install.sh)" -- --antigravity
+
+# CLI + Antigravity
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/install.sh)" -- --all
+```
+
+### 手动安装
+
+```bash
 git clone https://github.com/Jamkris/everything-gemini-code.git
 
 # 复制 Agents
 cp everything-gemini-code/agents/*.md ~/.gemini/agents/
 
 # 复制 Commands
-cp everything-gemini-code/commands/*.md ~/.gemini/commands/
+cp everything-gemini-code/commands/*.toml ~/.gemini/commands/
 
 # 复制 Skills
 cp -r everything-gemini-code/skills/* ~/.gemini/skills/
-
 ```
 
-> ⚠️ **注意：** 规则通过 `install.sh` 生成到 `~/.gemini/GEMINI.md`。手动安装时：`cp everything-gemini-code/templates/GEMINI_GLOBAL.md ~/.gemini/GEMINI.md`
+> ⚠️ **注意：** 规则通过 `install.sh` 生成到 `~/.gemini/GEMINI.md`。手动安装时执行：`cp everything-gemini-code/templates/GEMINI_GLOBAL.md ~/.gemini/GEMINI.md`
 
-### 选项 1：卸载（推荐）
+### 卸载
 
 ```bash
+# 扩展安装
 gemini extensions uninstall https://github.com/Jamkris/everything-gemini-code
+
+# 脚本安装（仅 Antigravity，选择性）
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/uninstall.sh)" -- --antigravity
+
+# 脚本安装（CLI + Antigravity，选择性）
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/uninstall.sh)" -- --all
+
+# 脚本安装（Antigravity，完全 — 删除目标目录中的所有文件）
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/refs/tags/v1.3.12/scripts/uninstall.sh)" -- --antigravity --purge
 ```
 
-### 选项 2：卸载（手动脚本）
+> **为什么钉版本标签？** 直接对移动的分支执行 `curl | bash` 在可复现性和供应链安全方面都不可靠。上面的 URL 指向 `v1.3.12` 发布标签。执行前请通过 <https://github.com/Jamkris/everything-gemini-code/blob/v1.3.12/scripts/install.sh> 审查实际运行的脚本。
 
-```bash
-# 选择性卸载（推荐）：仅卸载此扩展安装的文件。
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/uninstall.sh)" -- --antigravity
-
-# 完全卸载（警告）：删除目标目录中的所有文件。
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jamkris/everything-gemini-code/main/scripts/uninstall.sh)" -- --antigravity --purge
-```
+</details>
 
 ---
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -92,6 +92,27 @@ gemini extensions uninstall https://github.com/Jamkris/everything-gemini-code
 
 </details>
 
+### 首次命令
+
+安装完成后，在 Gemini CLI 中：
+
+```bash
+# 一次性审计整个仓库
+/egc-grok
+
+# 规划功能实现
+/egc-plan "添加用户认证"
+
+# 启动 TDD 工作流
+/egc-tdd "创建用户服务"
+
+# 直接调用 Agent
+@architect "设计微服务架构"
+@security-reviewer "审计此文件的注入漏洞"
+```
+
+> **Antigravity 用户注意：** 工作流使用裸名称安装（例如 `/tdd`、`/code-review`、`/build-fix`）。只有与 Antigravity 内置 `/plan` 冲突的 `/egc-plan` 会加上 `egc-` 前缀。在 Gemini CLI 中，所有命令都使用 `egc-` 前缀以避免与内置命令集冲突。
+
 ---
 
 ## 💻 使用方法


### PR DESCRIPTION
## Summary

Reshapes the top of the README so a first-time visitor sees what makes EGC different in 5 seconds instead of scrolling past 4 install options to find out. Also fixes a broken `npm install` code fence that's been rendering as raw text on GitHub.

## What changes

### New header lead

Before:
> **A comprehensive configuration suite for Gemini CLI / Antigravity.**
> This extension provides production-ready agents, skills, hooks, commands, rules, and MCP configurations designed to supercharge your development workflow with Gemini.

After:
> **Battle-tested agents, skills, and workflows for Gemini CLI / Antigravity.**
> Ports 183 skills and 48 agents from Everything Claude Code, retuned for Gemini's tool model. Adds Gemini-native features like `/egc-grok` — a whole-repo audit that uses Gemini's 1M context window in a single pass (Claude Code's 200K can't).

### Stats badges

Added next to license: `skills-183`, `agents-48`, `commands-80`. Static for now; refresh when inventory drifts ~5%+. Could move to dynamic shields.io if maintenance becomes a recurring ask.

### New "What you can do" section

Five bullets, each naming a real command or agent (all cross-checked against the repo):
- `/egc-grok` — whole-repo audit (1M context)
- `@planner` — phased plan + WAIT-for-confirm
- `/egc-tdd` + `@tdd-guide` — TDD with 80%+ coverage
- `@security-reviewer` — OWASP top 10 + secrets
- 183 skills, on-demand

### Quick Start collapsed to a single command

Before: 4 install options + auth + uninstall variants, all expanded inline → ~80 lines before reaching Usage.

After: one line (`gemini extensions install <repo>`) + API key env var. Everything else (script-based install, manual copy, dev-mode link, all uninstall variants) moved into a single `<details>` fold. Still discoverable, no longer pushes the value prop below the fold.

### Broken markdown cleaned up

The old Quick Start had a naked `npm install -g @google/gemini-cli@latest` line floating outside any code block, and a stray four-backtick fence. Rendered as raw text on GitHub. Gone.

### Untouched

- Language nav (line 1)
- Attribution + ecosystem-port disclaimer (lines 3–5, already polished from upstream feedback round)
- Usage section
- What's Inside file tree
- Troubleshooting / Contributing / License

## Risks

- **Count drift** — skill/agent/command numbers in badges go stale as inventory grows. Mitigation: refresh on releases that bump counts by 5%+. Or move to dynamic shields if it becomes annoying.
- **Tone change perceived as marketing** — the "Claude Code's 200K can't" line is factually correct and the ECC maintainer just merged two backports from this repo, so the relationship is healthy. Can soften to "uses Gemini's larger context window" if reviewer feedback comes in.
- **Existing user install path** — no install commands changed, just visually moved. Anyone following the previous README will still find their option, just inside a fold.

## Test plan

- [x] `npm run lint` clean (markdownlint included)
- [x] `npm test` 279/279
- [x] Cross-checked every command/agent name in the new section against `commands/` and `agents/`
- [x] Visual review — header, badges, "What you can do", Quick Start render cleanly in GitHub markdown preview

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the README header across English, Korean, and Chinese to surface the “why” in 5 seconds and streamline install. Pinned all script URLs to `v1.3.12`, documented the `--all` uninstall path, and added a “First Command” section to zh-CN for parity.

- **New Features**
  - New lead with upstream port context and Gemini-native `/egc-grok` callout.
  - Stats badges (skills 183, agents 48, commands 80); fixed stale counts in KO/ZH mirrors.
  - “What you can do” with real entry points: `/egc-grok`, `@planner`, `/egc-tdd` + `@tdd-guide`, `@security-reviewer`, on-demand skills.
  - Quick Start collapsed to `gemini extensions install …` + `GEMINI_API_KEY`; other methods in a single details fold; mirrored in `docs/ko-KR/README.md` and `docs/zh-CN/README.md`.
  - Added “首次命令” to `docs/zh-CN/README.md` with `/egc-grok`, `/egc-plan`, `/egc-tdd`, and the Antigravity prefix note.

- **Bug Fixes**
  - Fixed malformed markdown fence and a stray `npm install` line.
  - Pinned all `curl | bash` URLs to `refs/tags/v1.3.12` with a short audit note; mirrored in KO/ZH.
  - Documented `--all` uninstall and aligned uninstall examples/labels (selective and purge variants).

<sup>Written for commit 566052aa9926f0c64e45b5f67d01c05bab527b93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README rewritten with updated branding/badges and a Gemini-focused overview
  * Streamlined installation centering on GEMINI_API_KEY and a single install command
  * Expanded install methods (script/Antigravity, manual copy, developer linking) plus selective and full uninstall guidance (version-pinned examples)
  * Translated READMEs (Korean, Chinese) updated with new onboarding flow, examples, and updated agent/skill/command counts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jamkris/everything-gemini-code/pull/79)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->