### PR TITLE
fix(hooks): expand md-block whitelist with OSS standards + EGC convention dirs

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -43,14 +43,14 @@
 				"description": "Reminder before git push to review changes"
 			},
 			{
-				"matcher": "tool == \"write_file\" && tool_input.file_path matches \"\\\\.(md|txt)$\" && !(tool_input.file_path matches \"(README|CLAUDE|AGENTS|GEMINI|CONTRIBUTING|CHANGELOG|SECURITY|LICENSE|CODE_OF_CONDUCT|SUPPORT)\\\\.md$\")",
+				"matcher": "tool == \"write_file\" && tool_input.file_path matches \"\\\\.(md|txt)$\" && !(tool_input.file_path matches \"(README|CLAUDE|AGENTS|GEMINI|CONTRIBUTING|CHANGELOG|SECURITY|LICENSE|CODE_OF_CONDUCT|SUPPORT)\\\\.md$\") && !(tool_input.file_path matches \"(^|/)(agents|skills|workflows|rules|commands|docs|examples|mcp-configs|templates|upstream)/\")",
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|GEMINI|CONTRIBUTING|CHANGELOG|SECURITY|LICENSE|CODE_OF_CONDUCT|SUPPORT)\\.md$/.test(p)){console.error('[Hook] BLOCKED: Unnecessary documentation file creation');console.error('[Hook] File: '+p);console.error('[Hook] Use README.md for documentation instead');process.exit(1)}console.log(d)})\""
+						"command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';const isDocExt=/\\.(md|txt)$/.test(p);const isStandardName=/(README|CLAUDE|AGENTS|GEMINI|CONTRIBUTING|CHANGELOG|SECURITY|LICENSE|CODE_OF_CONDUCT|SUPPORT)\\.md$/.test(p);const isConventionDir=/(^|\\/)(agents|skills|workflows|rules|commands|docs|examples|mcp-configs|templates|upstream)\\//.test(p);if(isDocExt&&!isStandardName&&!isConventionDir){console.error('[Hook] BLOCKED: Unnecessary documentation file creation');console.error('[Hook] File: '+p);console.error('[Hook] Use README.md for documentation instead');process.exit(1)}console.log(d)})\""
 					}
 				],
-				"description": "Block creation of random .md files - keeps docs consolidated. Whitelisted: README, CLAUDE, AGENTS, GEMINI, CONTRIBUTING, CHANGELOG, SECURITY, LICENSE, CODE_OF_CONDUCT, SUPPORT (standard OSS files)."
+				"description": "Block creation of random .md files - keeps docs consolidated. Whitelisted: standard OSS names (README/CLAUDE/AGENTS/GEMINI/CONTRIBUTING/CHANGELOG/SECURITY/LICENSE/CODE_OF_CONDUCT/SUPPORT) AND files under EGC convention directories (agents/, skills/, workflows/, rules/, commands/, docs/, examples/, mcp-configs/, templates/, upstream/)."
 			},
 			{
 				"matcher": "tool == \"edit_file\" || tool == \"write_file\"",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -43,14 +43,14 @@
 				"description": "Reminder before git push to review changes"
 			},
 			{
-				"matcher": "tool == \"write_file\" && tool_input.file_path matches \"\\\\.(md|txt)$\" && !(tool_input.file_path matches \"README\\\\.md|CLAUDE\\\\.md|AGENTS\\\\.md|CONTRIBUTING\\\\.md\")",
+				"matcher": "tool == \"write_file\" && tool_input.file_path matches \"\\\\.(md|txt)$\" && !(tool_input.file_path matches \"(README|CLAUDE|AGENTS|GEMINI|CONTRIBUTING|CHANGELOG|SECURITY|LICENSE|CODE_OF_CONDUCT|SUPPORT)\\\\.md$\")",
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING)\\.md$/.test(p)){console.error('[Hook] BLOCKED: Unnecessary documentation file creation');console.error('[Hook] File: '+p);console.error('[Hook] Use README.md for documentation instead');process.exit(1)}console.log(d)})\""
+						"command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|GEMINI|CONTRIBUTING|CHANGELOG|SECURITY|LICENSE|CODE_OF_CONDUCT|SUPPORT)\\.md$/.test(p)){console.error('[Hook] BLOCKED: Unnecessary documentation file creation');console.error('[Hook] File: '+p);console.error('[Hook] Use README.md for documentation instead');process.exit(1)}console.log(d)})\""
 					}
 				],
-				"description": "Block creation of random .md files - keeps docs consolidated"
+				"description": "Block creation of random .md files - keeps docs consolidated. Whitelisted: README, CLAUDE, AGENTS, GEMINI, CONTRIBUTING, CHANGELOG, SECURITY, LICENSE, CODE_OF_CONDUCT, SUPPORT (standard OSS files)."
 			},
 			{
 				"matcher": "tool == \"edit_file\" || tool == \"write_file\"",


### PR DESCRIPTION
## Summary

`hooks/hooks.json` has a "block random `.md` file creation" hook that allowed exactly four filenames: `README`, `CLAUDE`, `AGENTS`, `CONTRIBUTING`. Everything else gets BLOCKED with `[Hook] BLOCKED: Unnecessary documentation file creation`.

That whitelist is too narrow on two axes:

1. **Standard OSS files** that this repo already contains and every other OSS repo expects (`SECURITY.md`, `CODE_OF_CONDUCT.md`, `CHANGELOG.md`, `LICENSE.md`, `SUPPORT.md`) all get blocked. `GEMINI.md` — the Gemini CLI analogue of `CLAUDE.md` — is also missing despite living at this repo's root.

2. **EGC convention directories.** Every contribution path EGC actively encourages — `skills/<name>/SKILL.md`, `agents/<name>.md`, `workflows/<name>.md`, `rules/<lang>/<name>.md`, `commands/<name>.md`, translated docs under `docs/<locale>/`, etc. — gets blocked. EGC has 51 workflow files and 48 agent files, so a contributor adding a 49th agent currently gets denied by EGC's own hook.

This PR fixes both classes.

## Behavior matrix (before → after)

| File path | Before | After | Why |
| --- | --- | --- | --- |
| `README.md` | allow | allow | unchanged |
| `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md` | allow | allow | unchanged |
| `GEMINI.md` | **BLOCK** | allow | added — Gemini CLI's `CLAUDE.md` analogue |
| `SECURITY.md` | **BLOCK** | allow | already exists in this repo |
| `CODE_OF_CONDUCT.md` | **BLOCK** | allow | already exists in this repo |
| `CHANGELOG.md`, `LICENSE.md`, `SUPPORT.md` | **BLOCK** | allow | standard OSS community-health files |
| `skills/python-patterns/SKILL.md` | **BLOCK** | allow | EGC skill bundle entry point |
| `skills/python-patterns/references/django.md` | **BLOCK** | allow | EGC skill reference doc |
| `agents/planner.md` | **BLOCK** | allow | EGC agent file |
| `workflows/tdd.md` | **BLOCK** | allow | EGC workflow file |
| `rules/typescript.md` | **BLOCK** | allow | EGC rule file |
| `commands/egc-grok.md` | **BLOCK** | allow | EGC command file |
| `docs/ko-KR/README.md` | allow | allow | unchanged (already worked) |
| `examples/foo.md` | **BLOCK** | allow | EGC examples dir |
| `templates/foo.md` | **BLOCK** | allow | EGC templates dir |
| `mcp-configs/README.md` | allow | allow | unchanged (README name) |
| `upstream/sync-rounds/2026-05-15.md` | **BLOCK** | allow | upstream sync notes |
| `TODO.md`, `NOTES.md`, `MEETING.md`, `random.md`, `random.txt` | BLOCK | BLOCK | still blocked — intended target |
| `src/foo.md` | BLOCK | BLOCK | non-convention path, still blocked |
| `tests/upstream-fixtures.md` | BLOCK | BLOCK | `upstream` as filename substring (not directory) — `(^|/)` anchor correctly distinguishes |

## Commit layout

Two commits so each axis can be reviewed independently:

1. `fix(hooks): expand md-block whitelist with standard OSS docs` — adds `GEMINI`, `CHANGELOG`, `SECURITY`, `LICENSE`, `CODE_OF_CONDUCT`, `SUPPORT` to the filename whitelist (regex `(README|CLAUDE|AGENTS|GEMINI|CONTRIBUTING|CHANGELOG|SECURITY|LICENSE|CODE_OF_CONDUCT|SUPPORT)\.md$`). 3-line diff. Reference: GitHub's community-standards list.

2. `fix(hooks): allow EGC convention directories in md-block hook` — adds a second exclusion clause for files under any path matching `(^|/)(agents|skills|workflows|rules|commands|docs|examples|mcp-configs|templates|upstream)/`. The `(^|/)` anchor prevents false matches on filenames that happen to contain those words (`upstream-fixtures.md` is not `upstream/fixtures.md`).

Both the matcher (line 46) and the inline script's regex (line 50) are kept in sync — the matcher decides *whether the hook fires*, the script decides *whether to block*, so they must agree.

## Tests

- `node scripts/ci/validate-hooks.js` — clean.
- `npm test` — 279/279 pass.
- `npm run lint` — clean.

No new test file because the hook is inline `node -e` JavaScript. The behaviour is verified against the table above via a direct regex check in the commit body, and the same regexes are validated by the JSON-schema hook validator.

## Test plan

- [ ] CI lint passes
- [ ] CI tests pass
- [ ] Manual: write each "Before BLOCK → After allow" path above through `write_file`, confirm the hook no longer blocks
- [ ] Manual: write each "still BLOCK" path, confirm the hook still blocks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the `.md/.txt` blocking hook to allow standard OSS docs and files inside EGC convention directories. This prevents false blocks for valid docs like `SECURITY.md`, `GEMINI.md`, and `skills/.../SKILL.md`.

- **Bug Fixes**
  - Whitelist standard filenames: `README`, `CLAUDE`, `AGENTS`, `GEMINI`, `CONTRIBUTING`, `CHANGELOG`, `SECURITY`, `LICENSE`, `CODE_OF_CONDUCT`, `SUPPORT`.
  - Allow docs under `agents/`, `skills/`, `workflows/`, `rules/`, `commands/`, `docs/`, `examples/`, `mcp-configs/`, `templates/`, `upstream/`.
  - Still block ad‑hoc files like `TODO.md`, `NOTES.md`, `random.md`, and non-convention paths.

<sup>Written for commit b90196263e964fd8d733d17992ff9e39ba1ce447. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

