### PR TITLE
docs(upstream): sync round 2026-05-15 — advance baseline to f7315016

### DIFF
--- a/upstream/.upstream-sync.json
+++ b/upstream/.upstream-sync.json
@@ -1,6 +1,6 @@
 {
   "upstream": "affaan-m/everything-claude-code",
-  "lastSyncedSha": "393d397efa40a9e9b6c7296df8181860ebf5047e",
-  "lastSyncedAt": "2026-05-13",
-  "notes": "Round 3 sync. Triage and per-commit dispositions: upstream/sync-rounds/2026-05-13.md. The SHA is the last commit *evaluated* — not necessarily the last commit ported. Ports landed: #75 (code-reviewer guardrails + prompt defense baselines). Net-new ECC features (PRD command, network architect agents, motion skills, Quarkus, Django Celery, cost tracking, frontend design, homelab configs) deferred to a future net-new round."
+  "lastSyncedSha": "f7315016c047abedc640e5434b9d74ff6a026994",
+  "lastSyncedAt": "2026-05-15",
+  "notes": "Round 4 sync. Triage and per-commit dispositions: upstream/sync-rounds/2026-05-15.md. The SHA is the last commit *evaluated* — not necessarily the last commit ported. In-flight port: feat/port-dev-server-block-from-ecc picks up the shell-substitution lib and dev-server-block hook from ECC main, where they landed via #1905 integrating EGC-authored #1889. Adjacent EGC-only fixes: fix/inline-matcher-quote-literal-false-positives, fix/md-block-hook-whitelist. Net-new ECC features (Ruby/Rails rules, supply-chain IOC scanner, command registry, GitHub Copilot adapter) deferred to a future net-new round alongside the rounds 1–3 carry-forwards."
 }

--- a/upstream/README.md
+++ b/upstream/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-393d397e-informational)
+![Baseline](https://img.shields.io/badge/baseline-f7315016-informational)
 
 EGC (Everything Gemini Code) is an **ecosystem port** of [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) by [@affaan-m](https://github.com/affaan-m). It is not an official ECC release and does not claim API or behavioral compatibility with ECC. Harness-specific behavior is verified inside Gemini CLI itself, not by reference to ECC's Claude Code behavior.
 
@@ -15,9 +15,9 @@ This document records how EGC tracks the upstream ECC repository and what was ch
 ## Upstream baseline
 
 - **Upstream repository**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **Last-synced upstream commit**: [`393d397efa40a9e9b6c7296df8181860ebf5047e`](https://github.com/affaan-m/everything-claude-code/commit/393d397efa40a9e9b6c7296df8181860ebf5047e)
-- **Last-synced date**: 2026-05-13
-- **Round notes**: see [`sync-rounds/2026-05-13.md`](sync-rounds/2026-05-13.md) for the latest round; [`sync-rounds/2026-05-12.md`](sync-rounds/2026-05-12.md) for the first triage. The SHA above is the last commit *evaluated*; not every commit in the focused range was ported.
+- **Last-synced upstream commit**: [`f7315016c047abedc640e5434b9d74ff6a026994`](https://github.com/affaan-m/everything-claude-code/commit/f7315016c047abedc640e5434b9d74ff6a026994)
+- **Last-synced date**: 2026-05-15
+- **Round notes**: see [`sync-rounds/2026-05-15.md`](sync-rounds/2026-05-15.md) for the latest round; [`sync-rounds/2026-05-13.md`](sync-rounds/2026-05-13.md) and [`sync-rounds/2026-05-12.md`](sync-rounds/2026-05-12.md) for prior rounds. The SHA above is the last commit *evaluated*; not every commit in the focused range was ported.
 - **Initial EGC commit**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 A machine-readable copy of this state lives at [`.upstream-sync.json`](./.upstream-sync.json). A CI validator (`scripts/ci/validate-upstream-sync.js`) asserts that the two files agree on the SHA, so a mismatch blocks the PR automatically.

--- a/upstream/sync-rounds/2026-05-15.md
+++ b/upstream/sync-rounds/2026-05-15.md
@@ -1,0 +1,109 @@
+# Upstream sync inventory — 2026-05-15
+
+Fourth sync round. Smaller in scope than 2026-05-12/05-13 because most of the upstream activity in this window was either internal ECC operations logging or net-new features that don't fit EGC's port surface.
+
+## Range
+
+- **Recorded baseline** in `upstream/.upstream-sync.json`: [`393d397e`](https://github.com/affaan-m/everything-claude-code/commit/393d397efa40a9e9b6c7296df8181860ebf5047e) (2026-05-13) — `docs: add prompt defense baselines`
+- **Upstream HEAD at this round**: [`f7315016`](https://github.com/affaan-m/everything-claude-code/commit/f7315016) (2026-05-15) — `feat: add command registry and coverage checks (#1906)`
+
+**Total drift**: 46 commits.
+
+## What was already in flight from EGC
+
+Two EGC-authored PRs landed in this window:
+
+- ECC [PR #1843](https://github.com/affaan-m/everything-claude-code/pull/1843) `fix: close block-no-verify bypass holes` — merged as `6be241a4`. Backport: EGC already has the equivalent token-scanner in `scripts/hooks/block-no-verify.js`; no further work on EGC.
+- ECC [PR #1889](https://github.com/affaan-m/everything-claude-code/pull/1889) `fix(hooks): close subshell bypass in pre-bash-dev-server-block` — integrated by the maintainer into ECC [PR #1905](https://github.com/affaan-m/everything-claude-code/pull/1905) (`fix: integrate recent hook and docs PRs`) and merged as `375d750b`. **Backport in progress** on EGC branch [`feat/port-dev-server-block-from-ecc`](https://github.com/Jamkris/everything-gemini-code/tree/feat/port-dev-server-block-from-ecc) — see disposition table below.
+
+A third PR is open against ECC:
+
+- ECC [PR #1912](https://github.com/affaan-m/everything-claude-code/pull/1912) `fix(hooks): close plain (...) and brace { ...; } bypass in gateguard destructive scan` — pending review. Not back-portable to EGC yet because EGC has no `gateguard-fact-force` hook (it is not in EGC's port surface).
+
+## Per-commit dispositions
+
+46 commits, grouped by path bucket. Buckets are mutually exclusive; the first matching rule wins.
+
+### E:shared-logic / D:other-harness — 4
+
+| SHA | Subject | Disposition |
+|---|---|---|
+| `375d750b` | `fix: integrate recent hook and docs PRs (#1905)` — bundles #1843, #1889, prisma-patterns skill, hook hardening, etc. | **Portable parts in flight on EGC branch `feat/port-dev-server-block-from-ecc`**. That EGC branch picks up `scripts/lib/shell-substitution.js`, `scripts/lib/shell-split.js`, and `scripts/hooks/pre-bash-dev-server-block.js` verbatim. The other parts of #1905 (config-protection hook, cost-tracker stop-hook, suggest-compact context) live outside EGC's port surface and are skipped. |
+| `0e169fec` | `fix: harden GateGuard destructive bash tokenizer` — gateguard subshell hardening | **skip** — EGC has no gateguard hook. The same hardening *idea* (quote-aware subshell extraction) is what the EGC dev-server-block port is bringing in via the shared lib. |
+| `d4728a0d` | `fix: fall back to ASCII instinct status bars` | **skip** — EGC has no instinct status bar yet. |
+| `766f4ee1` | `feat: add GitHub Copilot prompt support` | **skip** — EGC's adapter surface is Gemini CLI / Antigravity, not Copilot. Deferred candidate. |
+
+### F:ci/packaging — 5
+
+| SHA | Subject | Disposition |
+|---|---|---|
+| `f7315016` | `feat: add command registry and coverage checks (#1906)` | **deferred** — relevant pattern (CI surface for command catalog coverage) but EGC's command catalog format is different (`.toml` vs `.md`). Worth a focused EGC-native equivalent later. |
+| `7d15a228` | `security: add supply-chain IOC scanner (#1904)` | **deferred** — net-new security tooling, would be valuable for EGC, requires its own port-style PR. |
+| `42f04edc` | `ci: gate observability on release safety evidence` | **skip** — release-pipeline specific. |
+| `209abd40` | `ci: disable checkout credential persistence in privileged workflows (#1851)` | **adopt** — same hardening applies to EGC's `.github/workflows/`. Spinoff PR (small, ~5 lines per workflow). |
+| `797f2830` | `ci: require npm audit signature checks` | **deferred** — would tighten EGC's release pipeline too; covered by a separate spinoff in the security pass. |
+
+### A:skills / A:rules — 2
+
+| SHA | Subject | Disposition |
+|---|---|---|
+| `c2762dd5` | `feat: add Ruby and Rails rules` | **deferred** — net-new rule pair for a language EGC doesn't currently cover. Candidate for a future net-new round. |
+| `d1710bd2` | `Update/Add comprehensive tinystruct patterns reference documentation (#1895)` | **skip** — EGC does not include `tinystruct-patterns` skill. |
+
+### A:docs / H:meta — 32
+
+All AgentShield, ECC-Tools, JARVIS, and release-evidence roadmap sync commits — internal ECC operations logging that has no EGC-side correspondence.
+
+| Commits | Disposition |
+|---|---|
+| `f9384427`, `4423f10c`, `3b12fb27`, `4fb80d88`, `a27831c1`, `b24d762c`, `f94478e5`, `6cdac197`, `af3a2064`, `20f00c14`, `e7a6f137`, `75965020`, `c04baa8c`, `9082bded`, `3243a1c5`, `69401b28`, `bd4369e1`, `cb9702ca`, `0e66c838` | ECC-Tools roadmap sync — **skip** |
+| `9a5ed322`, `d844bd6b`, `cf54c791`, `f2be190d`, `2afef0f1`, `b2506f82`, `cbecf568`, `da04a6e3`, `cb3509ee` | AgentShield / supply-chain roadmap — **skip** |
+| `2d29643d`, `f6e13ab5`, `63f9bfc3`, `967e5c69`, `ff1594ea` | Release / roadmap meta — **skip** |
+
+### X:needs-review — 3
+
+| SHA | Subject | Disposition |
+|---|---|---|
+| `24867327` | `harden: remove shell access from read-only analyzers (#1850)` | **deferred** — would need a corresponding audit of EGC analyzer scripts to know whether the same hardening is necessary. Spinoff PR after a quick local audit. |
+| `6be241a4` | `fix: close block-no-verify bypass holes` (= ECC PR #1843, EGC-authored) | **already in EGC** — equivalent fix landed in EGC via a separate token-scanner rewrite. Verified by re-running EGC's `tests/hooks/block-no-verify.test.js` against the bypass payloads from #1843. |
+| `cb3509ee` | `docs: sync AgentShield adapter roadmap` | already covered in A:docs bucket — listed here only because the commit message style is ambiguous. |
+
+## Summary
+
+| Bucket | Count |
+|---|---|
+| E:shared-logic / D:other-harness | 4 |
+| F:ci/packaging | 5 |
+| A:skills / A:rules | 2 |
+| A:docs / H:meta | 32 |
+| X:needs-review | 3 |
+| **Total** | **46** |
+
+## Outcomes from this round
+
+- **In-flight EGC PR** (this round): [`feat/port-dev-server-block-from-ecc`](https://github.com/Jamkris/everything-gemini-code/tree/feat/port-dev-server-block-from-ecc) — ports `scripts/lib/shell-substitution.js`, `scripts/lib/shell-split.js`, and `scripts/hooks/pre-bash-dev-server-block.js` from ECC `main` and switches the EGC `hooks/hooks.json` dev-server matcher from an inline regex to the new script. Closes 4 false-negative variants (`yarn run dev`, `bun dev`, etc.) and 3 false-positive quote-literal cases the inline matcher couldn't distinguish.
+- **Adjacent fixes spun off into separate branches** (same round, separate PRs):
+  - [`fix/inline-matcher-quote-literal-false-positives`](https://github.com/Jamkris/everything-gemini-code/tree/fix/inline-matcher-quote-literal-false-positives) — tighten the three remaining inline matchers (tmux reminder, git push reminder, build analysis) with `^\s*` anchors and missing variants.
+  - [`fix/md-block-hook-whitelist`](https://github.com/Jamkris/everything-gemini-code/tree/fix/md-block-hook-whitelist) — expand the md-block hook whitelist with standard OSS files (SECURITY, CHANGELOG, etc.) and EGC convention directories (agents/, skills/, workflows/, etc.) that were previously blocked.
+
+## Deferred net-new ECC features (carry forward)
+
+Still waiting on a dedicated net-new round. New items from this window add to the queue:
+
+- Ruby / Rails rules (`c2762dd5`)
+- supply-chain IOC scanner (`7d15a228`)
+- command registry / coverage checks (`f7315016`) — needs EGC-native equivalent
+- GitHub Copilot prompt support (`766f4ee1`)
+
+Plus all items already deferred from rounds 1–3.
+
+## Baseline advance
+
+- **Before**: `393d397e` (2026-05-13)
+- **After**: `f7315016` (2026-05-15)
+
+Baseline files updated in this same commit set:
+- `upstream/.upstream-sync.json` — `lastSyncedSha` / `lastSyncedAt` / `notes`
+- `upstream/README.md` — Baseline badge, last-synced commit, last-synced date
+
+Localised mirrors (`upstream/ko-KR/`, `upstream/zh-CN/`) follow the same baseline; this round's note is published in English only because the per-commit disposition table doesn't translate cleanly without losing the SHA anchors. A localised summary at the bucket level can be added on request.


### PR DESCRIPTION
## Summary

Fourth upstream sync round. Inventories the 46 commits between EGC's previously-recorded ECC baseline `393d397e` (2026-05-13) and ECC `main` HEAD `f7315016` (2026-05-15), records per-commit dispositions, and advances the baseline files.

Same path-based bucketing as rounds 2026-05-12 and 2026-05-13. Buckets are mutually exclusive; the first matching rule wins.

## Inventory

| Bucket | Count | Notable items |
| --- | --- | --- |
| E:shared-logic / D:other-harness | 4 | `375d750b` (ECC PR #1905 integrating EGC-authored #1889 — being ported in branch `feat/port-dev-server-block-from-ecc`) |
| F:ci/packaging | 5 | `f7315016` command registry, `7d15a228` IOC scanner — both deferred to net-new round |
| A:skills / A:rules | 2 | `c2762dd5` Ruby/Rails rules — deferred |
| A:docs / H:meta | 32 | ECC-Tools / AgentShield roadmap sync — skip (no EGC equivalent) |
| X:needs-review | 3 | `6be241a4` (= ECC PR #1843, EGC-authored, already in EGC), `24867327` analyzer hardening (deferred) |
| **Total** | **46** | |

Full per-commit table with SHAs and disposition rationale is in `upstream/sync-rounds/2026-05-15.md`.

## What landed in EGC because of this round

This round catalyses three EGC-side PRs, opened as separate branches to keep review surfaces focused:

1. **In-flight port** (this round's primary output): [`feat/port-dev-server-block-from-ecc`](https://github.com/Jamkris/everything-gemini-code/tree/feat/port-dev-server-block-from-ecc) — picks up `scripts/lib/shell-substitution.js`, `scripts/lib/shell-split.js`, and `scripts/hooks/pre-bash-dev-server-block.js` from ECC `main` (where they landed via #1905 integrating EGC-authored #1889) and switches the `hooks/hooks.json` dev-server matcher from inline regex to the new script. Closes 4 false-negative variants and 3 false-positive quote-literal cases the inline matcher couldn't distinguish.

2. **Adjacent EGC-only fix**: [`fix/inline-matcher-quote-literal-false-positives`](https://github.com/Jamkris/everything-gemini-code/tree/fix/inline-matcher-quote-literal-false-positives) — tightens the three remaining inline matchers (tmux reminder, git push reminder, build analysis) with `^\s*` anchors and missing variants.

3. **Adjacent EGC-only fix**: [`fix/md-block-hook-whitelist`](https://github.com/Jamkris/everything-gemini-code/tree/fix/md-block-hook-whitelist) — expands the md-block hook whitelist with standard OSS files (SECURITY, CHANGELOG, etc.) and EGC convention directories (`agents/`, `skills/`, `workflows/`, `rules/`, …) that were previously over-blocked.

This PR is the *recording* PR — it does not include the code changes from those three branches. Once the three land, this round's baseline advance is consistent with what's in `main`; if any of them stays open, the deferred items list in the next sync round will record that explicitly.

## Commit layout

Two commits so the narrative artefact and the baseline flip stay separable:

1. `docs(upstream): add sync round note for 2026-05-15` — adds the new round file (`upstream/sync-rounds/2026-05-15.md`) only. No baseline change.
2. `docs(upstream): advance baseline to f7315016 (2026-05-15)` — flips `upstream/.upstream-sync.json` (`lastSyncedSha`, `lastSyncedAt`, `notes`) and the matching lines in `upstream/README.md` (baseline badge, last-synced commit link, last-synced date, round-notes pointer list) atomically.

The two-file update in commit (2) is done atomically because `scripts/ci/validate-upstream-sync.js` requires the SHA in the JSON and the SHA in the README to match — splitting them would briefly fail validation.

## Validation

- `node scripts/ci/validate-upstream-sync.js` — `OK — both files reference f731501`.
- `npm run lint` — clean (markdownlint passes on the new round note).
- No code changes; `npm test` not affected.

## Deferred net-new ECC features (carry forward)

New items added to the deferred queue from this round:

- Ruby / Rails rules (`c2762dd5`)
- supply-chain IOC scanner (`7d15a228`)
- command registry / coverage checks (`f7315016`) — needs EGC-native equivalent because EGC's command format is `.toml`, not `.md`
- GitHub Copilot prompt support (`766f4ee1`)

Plus all items already deferred from rounds 1–3.

## Test plan

- [ ] CI lint passes
- [ ] CI `validate-upstream-sync.js` confirms both files reference the same SHA
- [ ] Round note renders correctly on GitHub (tables, links, headings)
- [ ] Baseline badge in `upstream/README.md` shows the new SHA


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance the recorded ECC baseline to `f7315016` (2026-05-15) and add the round‑4 upstream sync inventory note.
Updates `upstream/.upstream-sync.json` and `upstream/README.md` to the new SHA/date and adds `upstream/sync-rounds/2026-05-15.md`; CI validator (`scripts/ci/validate-upstream-sync.js`) confirms both files reference the same SHA.

<sup>Written for commit 38c75ac5a4745b61a38004d1ee4962a75f72ee8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

