### PR TITLE
chore: release v1.3.13

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.12",
+	"version": "1.3.13",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.12",
+	"version": "1.3.13",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.12",
+	"version": "1.3.13",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.13

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the v1.3.13 release by bumping the `everything-gemini-code` version in `package.json`, `.gemini-plugin/plugin.json`, and `gemini-extension.json`. No code changes; metadata only.

<sup>Written for commit 0bbecd4aba880b25479c25ab966b85d3abed146d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

