### PR TITLE
docs(upstream): sync round 2026-05-18 — advance baseline to 3b7e0ba3

### DIFF
--- a/upstream/.upstream-sync.json
+++ b/upstream/.upstream-sync.json
@@ -1,6 +1,6 @@
 {
   "upstream": "affaan-m/everything-claude-code",
-  "lastSyncedSha": "f7315016c047abedc640e5434b9d74ff6a026994",
-  "lastSyncedAt": "2026-05-15",
-  "notes": "Round 4 sync. Triage and per-commit dispositions: upstream/sync-rounds/2026-05-15.md. The SHA is the last commit *evaluated* — not necessarily the last commit ported. In-flight port: feat/port-dev-server-block-from-ecc picks up the shell-substitution lib and dev-server-block hook from ECC main, where they landed via #1905 integrating EGC-authored #1889. Adjacent EGC-only fixes: fix/inline-matcher-quote-literal-false-positives, fix/md-block-hook-whitelist. Net-new ECC features (Ruby/Rails rules, supply-chain IOC scanner, command registry, GitHub Copilot adapter) deferred to a future net-new round alongside the rounds 1–3 carry-forwards."
+  "lastSyncedSha": "3b7e0ba30a027ffd3319c2f145c63076c296d80a",
+  "lastSyncedAt": "2026-05-18",
+  "notes": "Round 5 sync. Triage and per-commit dispositions: upstream/sync-rounds/2026-05-18.md. The SHA is the last commit *evaluated* — not necessarily the last commit ported. No new EGC-authored ECC PR opens this round because the two PRs that landed during this window (ECC #1970 workflow-security validator + #1971 ecc-metrics-bridge cost fixes) were EGC-authored against the previous baseline and are now part of ECC main. Deferred net-new ECC features added to the queue: uncloud skill, recsys-pipeline-architect skill, Thai (th) locale, full Japanese (ja-JP) translation, installer --locale flag, TypeScript 6 + @types/node 25 bumps, Zed install target."
 }

--- a/upstream/README.md
+++ b/upstream/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-f7315016-informational)
+![Baseline](https://img.shields.io/badge/baseline-3b7e0ba3-informational)
 
 EGC (Everything Gemini Code) is an **ecosystem port** of [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) by [@affaan-m](https://github.com/affaan-m). It is not an official ECC release and does not claim API or behavioral compatibility with ECC. Harness-specific behavior is verified inside Gemini CLI itself, not by reference to ECC's Claude Code behavior.
 
@@ -15,9 +15,9 @@ This document records how EGC tracks the upstream ECC repository and what was ch
 ## Upstream baseline
 
 - **Upstream repository**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **Last-synced upstream commit**: [`f7315016c047abedc640e5434b9d74ff6a026994`](https://github.com/affaan-m/everything-claude-code/commit/f7315016c047abedc640e5434b9d74ff6a026994)
-- **Last-synced date**: 2026-05-15
-- **Round notes**: see [`sync-rounds/2026-05-15.md`](sync-rounds/2026-05-15.md) for the latest round; [`sync-rounds/2026-05-13.md`](sync-rounds/2026-05-13.md) and [`sync-rounds/2026-05-12.md`](sync-rounds/2026-05-12.md) for prior rounds. The SHA above is the last commit *evaluated*; not every commit in the focused range was ported.
+- **Last-synced upstream commit**: [`3b7e0ba30a027ffd3319c2f145c63076c296d80a`](https://github.com/affaan-m/everything-claude-code/commit/3b7e0ba30a027ffd3319c2f145c63076c296d80a)
+- **Last-synced date**: 2026-05-18
+- **Round notes**: see [`sync-rounds/2026-05-18.md`](sync-rounds/2026-05-18.md) for the latest round; [`sync-rounds/2026-05-15.md`](sync-rounds/2026-05-15.md), [`sync-rounds/2026-05-13.md`](sync-rounds/2026-05-13.md), and [`sync-rounds/2026-05-12.md`](sync-rounds/2026-05-12.md) for prior rounds. The SHA above is the last commit *evaluated*; not every commit in the focused range was ported.
 - **Initial EGC commit**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 A machine-readable copy of this state lives at [`.upstream-sync.json`](./.upstream-sync.json). A CI validator (`scripts/ci/validate-upstream-sync.js`) asserts that the two files agree on the SHA, so a mismatch blocks the PR automatically.

--- a/upstream/sync-rounds/2026-05-18.md
+++ b/upstream/sync-rounds/2026-05-18.md
@@ -1,0 +1,90 @@
+# Upstream sync inventory — 2026-05-18
+
+Fifth sync round. Largest commit count to date (137 between baseline `f7315016` and HEAD `3b7e0ba3`), but very little portable surface — the round is dominated by ECC internal operations logging, a Japanese localization batch, and the integration of EGC-authored PRs from the previous rounds.
+
+## Range
+
+- **Recorded baseline** in `upstream/.upstream-sync.json`: [`f7315016`](https://github.com/affaan-m/everything-claude-code/commit/f7315016c047abedc640e5434b9d74ff6a026994) (2026-05-15) — `feat: add command registry and coverage checks (#1906)`
+- **Upstream HEAD at this round**: [`3b7e0ba3`](https://github.com/affaan-m/everything-claude-code/commit/3b7e0ba30a027ffd3319c2f145c63076c296d80a) (2026-05-18) — `docs: refresh catalog and operator dashboard`
+
+**Total drift**: 137 commits.
+
+## What was already in flight from EGC and now in ECC `main`
+
+Two EGC-authored PRs landed during this window and are part of the 137:
+
+- ECC [PR #1970](https://github.com/affaan-m/everything-claude-code/pull/1970) `fix(ci): close two validate-workflow-security bypasses (write-all + refs/pull)` — merged as `7bb31720` plus three preparatory commits (`7f971b7e`, `cdbc925d`, `e06d0382`). Backport-irrelevant: the ECC commits ARE the EGC source. EGC's earlier inline-matcher fixes (PR [#81](https://github.com/Jamkris/everything-gemini-code/pull/81)) are the downstream equivalent and already merged.
+
+- ECC [PR #1971](https://github.com/affaan-m/everything-claude-code/pull/1971) `fix(hooks): fix cost-reporting bugs in ecc-metrics-bridge (double-count + tail truncation)` — merged across six commits (`4f21ed2a`, `63c9788f`, `086e44c9`, `2de0ce45`, `4cafdb83`, `9b1d8918`). Includes two maintainer follow-ups that took the warning-dedup from process-local Map → tmp-backed signature cache. **Not back-portable to EGC** because `scripts/hooks/ecc-metrics-bridge.js` and the surrounding `ecc-statusline` / `ecc-context-monitor` cost-observability surface do not exist in EGC's port surface.
+
+## Per-bucket dispositions
+
+| Bucket | Count | Disposition |
+|---|---|---|
+| A:skills (net-new) | 6 | **deferred** — `uncloud` and `recsys-pipeline-architect` are two new community skills with their support commits |
+| A:docs (ja-JP localization) | ~15 | **deferred** — large Japanese translation batch; out of scope for this round |
+| A:docs (Thai) | 2 | **deferred** — new `th` README + a review-nit fix |
+| A:docs / H:meta (rc1 / catalog / readiness / billing logs) | ~50 | **skip** — internal ECC release-prep telemetry, no EGC analogue |
+| A:docs (ECC-Tools / AgentShield / Linear roadmap sync) | ~42 | **skip** — same logging surface, no EGC analogue |
+| E:shared-logic (EGC-authored, already in ECC) | 10 | **already in EGC** — see "What was already in flight" above |
+| F:ci/installer | 4 | **mostly defer** — see detailed table below |
+| D:other-harness (cost monitor, IOC scanner, gh-token-monitor) | ~6 | **skip** — no EGC port surface |
+| X:chore/deps | 6 | **defer** — TypeScript 6, @types/node 25 bumps; pin-by-pin tracking is out of scope |
+| **Total** | **~137** | |
+
+## Detailed dispositions (the non-skip subset)
+
+| SHA | Subject | Disposition |
+|---|---|---|
+| `8b6aed0b` | `feat(skills): add uncloud skill` | **deferred** — net-new skill; candidate for the next net-new round. Both companion commits (`caee7cf7`, `2e5f30f6`) bundled with it. |
+| `4b96af8f` | `feat: add recsys-pipeline-architect skill (community)` | **deferred** — net-new community skill; same disposition. |
+| `989559a7` | `docs(th): add Thai (th) README translation` | **deferred** — new locale would also need the `docs/th/`, `upstream/th/`, and `install.sh --locale th` glue. Larger than a single sync round. |
+| `ec9ace9c` | `docs: add native Japanese translation of ECC documentation (ja-JP)` | **deferred** — same shape; bundled across ~10 ja-JP commits this window. |
+| `71aedad8` | `feat(installer): add --locale flag for translated docs installation` | **potentially adopt** — EGC already has `docs/ko-KR/` and `docs/zh-CN/` mirrors; a `--locale` flag would replace today's full-mirror copy with a selective install. Worth investigating in a follow-up round once we decide whether EGC's install model wants per-locale selectivity. |
+| `666b4e22` | `fix(installer): harden locale docs install` | **paired with `71aedad8`** — defer together. |
+| `b47dfa95` | `fix: add context monitor cost warning opt-out` | **skip** — `ecc-context-monitor.js` is not in EGC's port surface. |
+| `74204415` `fb6d4a71` | supply-chain IOC marker tightening | **skip** — `scan-supply-chain-iocs.js` is not in EGC's port surface. |
+| `36d390aa` | `security: cover gh-token-monitor token persistence` | **skip** — `gh-token-monitor` not in EGC. |
+| `2371a3cf` `744f4169` | Zed install target | **skip** — EGC is a Gemini CLI / Antigravity port, not multi-editor. |
+| `99e5a2f4` `344a9bdf` `09a1cf1d` `b66ae3fb` | TypeScript 6 + @types/node 25 bumps | **deferred** — EGC stays on the tested toolchain until a focused dependency-bump PR. |
+
+## Why no portable PR opens this round
+
+Three reasons converge:
+
+1. **The high-value targets I would normally pick are now upstream.** The two PRs I would have opened this round (workflow-security validator hardening, metrics-bridge double-count) were already opened against ECC during round 4's window and merged during round 5's. There is nothing left in the same shape to backport — they ARE the backport, in the other direction.
+
+2. **The rest of round 5 is operations log.** ~92 of 137 commits are ECC-Tools / AgentShield / Linear / rc1-readiness sync logs that have no EGC analogue. They are noise from EGC's perspective.
+
+3. **The remaining 35-ish commits are net-new candidates that don't fit a single-round PR.** A new locale (Thai or Japanese), a new skill bundle, or a TypeScript 6 bump are each substantial enough to want their own focused round.
+
+## Outcomes from this round
+
+- **Baseline advanced** `f7315016` → `3b7e0ba3`. Closes EGC tracker issue [#77](https://github.com/Jamkris/everything-gemini-code/issues/77) on the next `upstream-drift.yml` cron tick.
+- **Net-new queue grows** with `uncloud` skill, `recsys-pipeline-architect` skill, Thai locale, Japanese locale, `--locale` installer flag.
+- **No new ECC PR opens from EGC this round** — the previous two rounds' EGC-authored PRs cover ECC's recent gateguard / cost-reporting / workflow-validator surface, and the round's remaining commits sit outside EGC's port surface.
+
+## Deferred net-new ECC features (carry forward)
+
+New items added to the deferred queue:
+
+- `uncloud` skill (community contribution)
+- `recsys-pipeline-architect` skill (community contribution)
+- Thai (`th`) README + docs locale
+- Japanese (`ja-JP`) full documentation translation (~15 commits)
+- Installer `--locale` flag for selective translated-docs installation
+- TypeScript 6 + @types/node 25 toolchain bumps
+- Zed install target (most likely permanent-skip given EGC's Gemini-only positioning)
+
+Plus all items already deferred from rounds 1–4.
+
+## Baseline advance
+
+- **Before**: `f7315016` (2026-05-15)
+- **After**: `3b7e0ba3` (2026-05-18)
+
+Baseline files updated in the same commit set:
+- `upstream/.upstream-sync.json` — `lastSyncedSha` / `lastSyncedAt` / `notes`
+- `upstream/README.md` — Baseline badge, last-synced commit link, last-synced date, round-notes pointer list
+
+Localised mirrors (`upstream/ko-KR/`, `upstream/zh-CN/`) follow the same baseline. As with round 4, this round's per-commit disposition table is published in English only; a localised bucket-level summary can be added on request.


### PR DESCRIPTION
## Summary

Fifth upstream sync round. Inventories 137 commits between baseline `f7315016` (2026-05-15) and ECC HEAD `3b7e0ba3` (2026-05-18) and advances the baseline files.

| Bucket | Count | Disposition |
|---|---|---|
| EGC-authored, already in ECC main | 10 | already in EGC (ECC PR #1970 + #1971) |
| ECC ops logs (Tools / AgentShield / rc1 / readiness) | ~92 | skip |
| ja-JP localization batch | ~15 | deferred |
| Net-new skills / locales / installer flag / deps bumps | ~14 | deferred |
| Out-of-port-surface (cost-monitor / IOC scanner / etc.) | ~6 | skip |
| **Total** | **137** | |

Full per-commit table in `upstream/sync-rounds/2026-05-18.md`.

## What's notable

**No new EGC-authored ECC PR opens this round.** The two PRs that would have been this round's top targets — workflow-security validator hardening + `ecc-metrics-bridge` cost-reporting — were opened upstream during round 4 and merged during this round's window. They ARE the backport, in the other direction.

The remaining 127 commits split into ECC operations log (no EGC analogue), substantial deferred candidates (ja-JP locale, new skills, installer `--locale` flag), and out-of-port-surface ECC hooks (`ecc-context-monitor`, `gh-token-monitor`, supply-chain IOC scanner, Zed install target).

## Commit layout

Same shape as round 4: two commits so the narrative artefact and the baseline flip stay separable.

1. `docs(upstream): add sync round note for 2026-05-18` — adds the new round file only.
2. `docs(upstream): advance baseline to 3b7e0ba3 (2026-05-18)` — flips `upstream/.upstream-sync.json` AND `upstream/README.md` atomically (the validator requires the SHA to match).

## Validation

- `node scripts/ci/validate-upstream-sync.js` → `OK — both files reference 3b7e0ba`
- `npm run lint` — clean
- No code changes; `npm test` unaffected

Closes #77 on the next `upstream-drift.yml` cron tick.

## Deferred net-new ECC features (carry forward)

New to the queue from this round:
- `uncloud` skill (community contribution)
- `recsys-pipeline-architect` skill (community contribution)
- Thai (`th`) README + docs locale
- Japanese (`ja-JP`) full documentation translation
- Installer `--locale` flag for selective translated-docs installation
- TypeScript 6 + `@types/node` 25 toolchain bumps
- Zed install target (likely permanent-skip given EGC's Gemini-only positioning)

Plus all items already deferred from rounds 1–4.

## Test plan

- [ ] CI lint passes
- [ ] CI `validate-upstream-sync.js` confirms both files reference the same SHA
- [ ] Round note renders correctly on GitHub (tables, links)
- [ ] Baseline badge in `upstream/README.md` shows the new SHA
- [ ] Issue #77 auto-closes on next `upstream-drift.yml` run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advances the upstream baseline to 3b7e0ba3 (2026-05-18) and records the round‑5 inventory to keep EGC in sync with ECC. Updates `upstream/.upstream-sync.json` and `upstream/README.md`; adds `upstream/sync-rounds/2026-05-18.md`; no code changes.

<sup>Written for commit 2a11811082e9d5a5edae9c9a87f07f63563c0960. Summary will update on new commits. <a href="https://cubic.dev/pr/Jamkris/everything-gemini-code/pull/85?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed fifth upstream sync round with updated metadata and baseline references.

* **Documentation**
  * Updated upstream baseline information and added sync round documentation including disposition summaries and feature tracking details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jamkris/everything-gemini-code/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->