### PR TITLE
chore: release v1.3.14

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.13",
+	"version": "1.3.14",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.13",
+	"version": "1.3.14",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.13",
+	"version": "1.3.14",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.14

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `everything-gemini-code` to v1.3.14 across `package.json`, `.gemini-plugin/plugin.json`, and `gemini-extension.json` to prepare the release and keep manifests in sync.

<sup>Written for commit c5fd746fb44340e3788cf4586d702b79da9c3733. Summary will update on new commits. <a href="https://cubic.dev/pr/Jamkris/everything-gemini-code/pull/86?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

