### PR TITLE
docs(upstream): sync round 6 — advance baseline to 1e8c7e7 (2026-05-26)

### DIFF
--- a/upstream/.upstream-sync.json
+++ b/upstream/.upstream-sync.json
@@ -1,6 +1,6 @@
 {
   "upstream": "affaan-m/everything-claude-code",
-  "lastSyncedSha": "3b7e0ba30a027ffd3319c2f145c63076c296d80a",
-  "lastSyncedAt": "2026-05-18",
-  "notes": "Round 5 sync. Triage and per-commit dispositions: upstream/sync-rounds/2026-05-18.md. The SHA is the last commit *evaluated* — not necessarily the last commit ported. No new EGC-authored ECC PR opens this round because the two PRs that landed during this window (ECC #1970 workflow-security validator + #1971 ecc-metrics-bridge cost fixes) were EGC-authored against the previous baseline and are now part of ECC main. Deferred net-new ECC features added to the queue: uncloud skill, recsys-pipeline-architect skill, Thai (th) locale, full Japanese (ja-JP) translation, installer --locale flag, TypeScript 6 + @types/node 25 bumps, Zed install target."
+  "lastSyncedSha": "1e8c7e7994223e0ff337d1626cd08e04a1ae67ed",
+  "lastSyncedAt": "2026-05-26",
+  "notes": "Round 6 sync. Triage and per-commit dispositions: upstream/sync-rounds/2026-05-26.md. The SHA is the last commit *evaluated* — not necessarily the last commit ported. No new EGC-authored ECC PR opens this round; two EGC-authored PRs that landed during this window (ECC #1982 Unicode Tag denylist in check-unicode-safety + ECC #1983 writeBridgeAtomic/writeWarnState atomic-write race) target ECC-only file surfaces and are not back-portable to EGC. One trivial clean-delete candidate filed for follow-up: 812d4d0 (delete skills/strategic-compact/suggest-compact.sh, unreferenced in EGC). Deferred net-new ECC features added to the queue: Blender motion-state inspection skill, harness-audit integration scoring extension (ECC #1990), continuous-learning-v2 project-registry maintenance."
 }

--- a/upstream/README.md
+++ b/upstream/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-3b7e0ba3-informational)
+![Baseline](https://img.shields.io/badge/baseline-1e8c7e7-informational)
 
 EGC (Everything Gemini Code) is an **ecosystem port** of [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) by [@affaan-m](https://github.com/affaan-m). It is not an official ECC release and does not claim API or behavioral compatibility with ECC. Harness-specific behavior is verified inside Gemini CLI itself, not by reference to ECC's Claude Code behavior.
 
@@ -15,9 +15,9 @@ This document records how EGC tracks the upstream ECC repository and what was ch
 ## Upstream baseline
 
 - **Upstream repository**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **Last-synced upstream commit**: [`3b7e0ba30a027ffd3319c2f145c63076c296d80a`](https://github.com/affaan-m/everything-claude-code/commit/3b7e0ba30a027ffd3319c2f145c63076c296d80a)
-- **Last-synced date**: 2026-05-18
-- **Round notes**: see [`sync-rounds/2026-05-18.md`](sync-rounds/2026-05-18.md) for the latest round; [`sync-rounds/2026-05-15.md`](sync-rounds/2026-05-15.md), [`sync-rounds/2026-05-13.md`](sync-rounds/2026-05-13.md), and [`sync-rounds/2026-05-12.md`](sync-rounds/2026-05-12.md) for prior rounds. The SHA above is the last commit *evaluated*; not every commit in the focused range was ported.
+- **Last-synced upstream commit**: [`1e8c7e7994223e0ff337d1626cd08e04a1ae67ed`](https://github.com/affaan-m/everything-claude-code/commit/1e8c7e7994223e0ff337d1626cd08e04a1ae67ed)
+- **Last-synced date**: 2026-05-26
+- **Round notes**: see [`sync-rounds/2026-05-26.md`](sync-rounds/2026-05-26.md) for the latest round; [`sync-rounds/2026-05-18.md`](sync-rounds/2026-05-18.md), [`sync-rounds/2026-05-15.md`](sync-rounds/2026-05-15.md), [`sync-rounds/2026-05-13.md`](sync-rounds/2026-05-13.md), and [`sync-rounds/2026-05-12.md`](sync-rounds/2026-05-12.md) for prior rounds. The SHA above is the last commit *evaluated*; not every commit in the focused range was ported.
 - **Initial EGC commit**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 A machine-readable copy of this state lives at [`.upstream-sync.json`](./.upstream-sync.json). A CI validator (`scripts/ci/validate-upstream-sync.js`) asserts that the two files agree on the SHA, so a mismatch blocks the PR automatically.

--- a/upstream/ko-KR/README.md
+++ b/upstream/ko-KR/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-393d397e-informational)
+![Baseline](https://img.shields.io/badge/baseline-1e8c7e7-informational)
 
 EGC (Everything Gemini Code) 는 [@affaan-m](https://github.com/affaan-m) 의 [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) 를 기반으로 한 **생태계 포트(ecosystem port)** 입니다. ECC의 공식 릴리스가 아니며, ECC와의 API/동작 호환성을 주장하지 않습니다. 하네스 고유 동작은 ECC의 Claude Code 거동을 기준 삼지 않고 Gemini CLI 내부에서 직접 검증합니다.
 
@@ -15,9 +15,9 @@ EGC (Everything Gemini Code) 는 [@affaan-m](https://github.com/affaan-m) 의 [E
 ## 업스트림 베이스라인
 
 - **업스트림 레포지토리**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **마지막 동기화 커밋**: [`393d397efa40a9e9b6c7296df8181860ebf5047e`](https://github.com/affaan-m/everything-claude-code/commit/393d397efa40a9e9b6c7296df8181860ebf5047e)
-- **마지막 동기화 일자**: 2026-05-13
-- **라운드 노트**: 최신 라운드는 [`sync-rounds/2026-05-13.md`](../sync-rounds/2026-05-13.md), 첫 triage는 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md) 참고. 위 SHA는 *평가한* 마지막 커밋이며, 포커스 범위의 모든 커밋이 포팅되지는 않았습니다.
+- **마지막 동기화 커밋**: [`1e8c7e7994223e0ff337d1626cd08e04a1ae67ed`](https://github.com/affaan-m/everything-claude-code/commit/1e8c7e7994223e0ff337d1626cd08e04a1ae67ed)
+- **마지막 동기화 일자**: 2026-05-26
+- **라운드 노트**: 최신 라운드는 [`sync-rounds/2026-05-26.md`](../sync-rounds/2026-05-26.md), 이전 라운드는 [`sync-rounds/2026-05-18.md`](../sync-rounds/2026-05-18.md), [`sync-rounds/2026-05-15.md`](../sync-rounds/2026-05-15.md), [`sync-rounds/2026-05-13.md`](../sync-rounds/2026-05-13.md), 첫 triage는 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md) 참고. 위 SHA는 *평가한* 마지막 커밋이며, 포커스 범위의 모든 커밋이 포팅되지는 않았습니다.
 - **EGC 최초 커밋**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 이 상태의 기계 판독용 사본은 [`.upstream-sync.json`](../.upstream-sync.json) 에 있습니다. CI validator (`scripts/ci/validate-upstream-sync.js`) 가 두 파일의 SHA 일치를 강제하며, 불일치가 발생한 PR은 자동으로 차단됩니다.

--- a/upstream/sync-rounds/2026-05-26.md
+++ b/upstream/sync-rounds/2026-05-26.md
@@ -1,0 +1,110 @@
+# Upstream sync inventory — 2026-05-26
+
+Sixth sync round. 102 commits between baseline `3b7e0ba3` and HEAD `1e8c7e7`, dominated again by ECC release-readiness / billing-readback / AgentShield / Linear roadmap evidence logs with no EGC analogue. Two EGC-authored PRs landed upstream during this window (`#1982` Unicode Tag denylist, `#1983` `writeBridgeAtomic` race), both targeting ECC-only file surfaces; no EGC-side port follows because the surface does not exist here. One trivial clean-delete is the only candidate for a follow-up port PR; everything else is either out-of-surface, defer, or skip.
+
+## Range
+
+- **Recorded baseline** in `upstream/.upstream-sync.json`: [`3b7e0ba3`](https://github.com/affaan-m/everything-claude-code/commit/3b7e0ba30a027ffd3319c2f145c63076c296d80a) (2026-05-18) — `docs: refresh catalog and operator dashboard`
+- **Upstream HEAD at this round**: [`1e8c7e7`](https://github.com/affaan-m/everything-claude-code/commit/1e8c7e7994223e0ff337d1626cd08e04a1ae67ed) (2026-05-20) — `docs: sync live native payments gate evidence`
+
+**Total drift**: 102 commits.
+
+## What was already in flight from EGC and now in ECC `main`
+
+Two EGC-authored PRs landed during this window:
+
+- ECC [PR #1982](https://github.com/affaan-m/everything-claude-code/pull/1982) `fix(ci): cover Unicode Tag block + other invisibles in check-unicode-safety (ASCII smuggling)` — merged across three commits (`e3483fd`, `b068069`, `33ed494`). Extends `scripts/ci/check-unicode-safety.js`'s denylist to cover the Unicode Tag block (`U+E0000–U+E007F`) — the canonical "ASCII smuggling" / "Tag Smuggling" LLM prompt-injection vector — plus six other widely-cited invisible code points (`U+180E`, `U+115F`, `U+1160`, `U+2061–U+2064`, `U+3164`). **Not back-portable to EGC** because `scripts/ci/check-unicode-safety.js` does not exist in EGC's port surface — the validator is ECC-only. If EGC adds a Unicode-safety validator in a future round, the denylist (eight ranges) is the canonical reference.
+
+- ECC [PR #1983](https://github.com/affaan-m/everything-claude-code/pull/1983) `fix(lib/hooks): eliminate ENOENT + corruption race in writeBridgeAtomic and writeWarnState` — merged across six commits (`28548f6`, `7c2f713`, `5acb01a`, `d904edc`, `116e61d`, `f93e8f6`). Switches both atomic-write call sites to a per-process unique tmp suffix (eliminates concurrent-writer ENOENT races) and adds a Windows EPERM/EACCES/EBUSY rename retry via a shared `renameWithRetry` helper. **Not back-portable to EGC** because the `ecc-metrics-bridge` / `ecc-context-monitor` cost-observability surface does not exist in EGC — same surface-out-of-scope reasoning as round 5's PR #1971 disposition.
+
+Net effect: two more high-value security/robustness fixes landed in ECC main during this window. Both originated as EGC-authored upstream contributions, both close on the ECC side, neither produces a downstream EGC port because the underlying file surface is ECC-only.
+
+## Per-bucket dispositions
+
+| Bucket | Count | Disposition |
+|---|---|---|
+| E:shared-logic (EGC-authored, already in ECC) | 9 | **already upstream** — see "What was already in flight" above |
+| A:docs/sync (May 18–20 readiness, billing readback, dashboard refresh, Linear/AgentShield/ECC-Tools, README rename, release supply-chain evidence) | 63 | **skip** — internal ECC release-prep telemetry / cosmetic README rename, no EGC analogue |
+| A:chore (ECC 2.0 release machinery: video suite, owner approval packet, hypergrowth release lane, suite count evidence) | 8 | **skip** — release-pipeline specific to ECC |
+| A:test (release/dashboard fixtures, Windows lifecycle, release-workflow line endings, insaits monitor, platform audit) | 6 | **skip** — paired with A:docs / release machinery |
+| A:chore (release) — `7911af4` security: scope release oidc publishing | 1 | **skip** — ECC release workflow specific |
+| A:skills (net-new) — `922d2d8` Blender motion-state inspection | 1 | **deferred** — community contribution; same disposition shape as round 5's `uncloud` / `recsys-pipeline-architect` |
+| A:misc — `4d6fc19` include blender skill in install manifest | 1 | **paired with `922d2d8`** — defer together |
+| A:skills (delete) — `812d4d0` delete `skills/strategic-compact/suggest-compact.sh` | 1 | **portable (small follow-up)** — clean `-54` LOC delete; EGC has the same leftover file and the `.sh` is unreferenced by any EGC code path |
+| D:other-harness (claude-project install target) — `7004a66` `b2c2616` `98bd517` | 3 | **skip** — adapter installs ECC content into a per-project `.claude/` directory; EGC's install targets are Gemini CLI / Antigravity |
+| D:other-harness (gateguard) — `14d88e5` preserve quoted git introspection args | 1 | **skip** — `scripts/hooks/gateguard-fact-force.js` not in EGC's port surface (same shape as round 4's gateguard disposition) |
+| X:fix (LLM providers) — `cc62e89` `eb0d893` `80f6c27` OpenAI / AstraFlow empty-choices guard | 3 | **skip** — `src/llm/providers/*.py` not in EGC's port surface |
+| X:fix (MCP health-check) — `386326d` treat HTTP 406 probes as reachable | 1 | **skip** — `scripts/hooks/mcp-health-check.js` not in EGC |
+| X:fix (IOC scanner) — `04d4d81` ignore defensive ioc deny rules | 1 | **skip** — `scripts/security/scan-supply-chain-iocs.js` not in EGC |
+| X:hooks — `6cb194a` avoid escaped quotes in plugin bootstrap | 1 | **skip** — touches `scripts/lib/resolve-ecc-root.js`, which does not exist in EGC |
+| X:feat — `af9b2c1` harness-audit integration scoring extension (#1990) | 1 | **deferred** — substantial rewrite (+214 LOC `scripts/harness-audit.js`, +192 LOC tests, +17 LOC `commands/harness-audit.md`). EGC has the script but the command lives in `.toml` form; needs adapter work |
+| X:learning — `bc519e5` continuous-learning-v2 project registry maintenance | 1 | **deferred** — 757-line change. EGC has `observe.sh` + `instinct-cli.py` but no `detect-project.sh`; non-trivial adapter work |
+| **Total** | **102** | |
+
+## Detailed dispositions (the non-skip subset)
+
+| SHA | Subject | Disposition |
+|---|---|---|
+| `812d4d0` | `Delete skills/strategic-compact/suggest-compact.sh` | **portable** — EGC has the same leftover file at `skills/strategic-compact/suggest-compact.sh` (52 LOC `.sh`); EGC's actual runtime path uses `scripts/hooks/suggest-compact.js` (Node), referenced from `skills/strategic-compact/SKILL.md` and `tests/hooks/hooks.test.js`. The `.sh` is unused by any EGC code path — `rg suggest-compact.sh` returns zero hits outside the file itself. Clean candidate for a small follow-up PR (one-file delete + no test diff). |
+| `922d2d8` | `Add Blender motion state inspection skill` | **deferred** — net-new community skill, same disposition as `uncloud` / `recsys-pipeline-architect` from round 5. Candidate for a future net-new-skills round. |
+| `4d6fc19` | `fix: include blender skill in install manifest` | **paired with `922d2d8`** — defer together. |
+| `af9b2c1` | `feat: extend harness audit integration scoring (#1990)` | **deferred** — scoring extension is genuinely useful (GitHub integration checks, CODEOWNERS coverage, dynamic applicable-category metadata) and EGC has `scripts/harness-audit.js`, but the commit assumes the ECC `.md` command-file shape that EGC has already translated to `.toml`. Port needs adapter work; better as a focused PR. |
+| `bc519e5` | `fix(learning): add project registry maintenance` | **deferred** — large diff (706 additions / 51 deletions across 7 files). EGC's `continuous-learning-v2` skill is partially present (`observe.sh`, `instinct-cli.py`) but missing `detect-project.sh`. Adapter work non-trivial; defer to focused round. |
+| `7004a66` `b2c2616` `98bd517` | `feat(install-targets): add claude-project adapter` + paired fix/test | **skip** — adapter installs ECC content into a per-project `.claude/` directory; EGC's install targets are Gemini CLI / Antigravity, never Claude Code. Permanent-skip absent a `gemini-project` analogue. |
+| `cc62e89` `eb0d893` `80f6c27` `aa4ae86` | OpenAI / AstraFlow Python provider empty-choices guards | **skip** — `src/llm/providers/*.py` does not exist in EGC's port surface (EGC does not include the Python LLM-provider layer). |
+| `386326d` | `fix: treat MCP HTTP 406 probes as reachable` | **skip** — `scripts/hooks/mcp-health-check.js` does not exist in EGC. |
+| `04d4d81` | `fix: ignore defensive ioc deny rules` | **skip** — `scan-supply-chain-iocs.js` is not in EGC. |
+| `6cb194a` | `fix(hooks): avoid escaped quotes in plugin bootstrap` | **skip** — touches `scripts/lib/resolve-ecc-root.js` and the inline `node -e` resolver embedded in `hooks/hooks.json`. EGC has neither `resolve-ecc-root.js` nor the embedded resolver pattern (EGC's hook commands shell out to script files directly). |
+| `14d88e5` | `fix(gateguard): preserve quoted git introspection args` | **skip** — `scripts/hooks/gateguard-fact-force.js` is not in EGC's port surface (same as round 4's gateguard disposition). |
+| `7911af4` | `security: scope release oidc publishing` | **skip** — ECC release workflow specific. |
+| `9819626` | `Add release approval gate` | **skip** — ECC release machinery. |
+| `bf17737` | `test: stabilize repair lifecycle on Windows` | **skip** — `tests/integration/repair-lifecycle.test.*` not in EGC. |
+
+## Why no portable PR opens this round
+
+Three patterns converge again:
+
+1. **The two high-value upstream-going fixes are already merged.** ECC PR #1982 (Unicode Tag) and #1983 (`writeBridgeAtomic` race) were EGC-authored against ECC's own surface — there is nothing left in those shapes to backport because the validator and the atomic-bridge writer do not exist in EGC.
+
+2. **The bulk of the window is operations log.** 78 of 102 commits are May 18–20 release readiness / billing readback / dashboard refresh / AgentShield / Linear roadmap evidence / video-suite chore / test-fixture refresh — internal ECC operations with no EGC analogue.
+
+3. **The remaining 24 commits are either EGC-authored upstream (9), out-of-surface fixes (9 across Claude-project install target, Python LLM providers, MCP health-check, gateguard, IOC scanner, plugin bootstrap resolver), or substantial enough to want a focused PR of their own (5 across harness-audit scoring, continuous-learning-v2 project registry, Blender skill bundle, the trivial `suggest-compact.sh` delete).** None of the substantial items fits a single sync-round PR.
+
+The one trivial clean-delete (`812d4d0`) is portable and could be bundled with this baseline advance, but it is filed as a small follow-up so that a regression there does not block the baseline cycle.
+
+## Outcomes from this round
+
+- **Baseline advanced** `3b7e0ba3` → `1e8c7e7`. Closes EGC tracker issue [#87](https://github.com/Jamkris/everything-gemini-code/issues/87) on the next `upstream-drift.yml` cron tick.
+- **No new ECC PR opens from EGC this round.** Two EGC-authored PRs (#1982, #1983) merged during the window; both target ECC-only surface.
+- **Net-new queue grows** with the Blender motion-state inspection skill and the harness-audit integration-scoring extension (#1990).
+- **One trivial port candidate identified** (`812d4d0` clean-delete of `skills/strategic-compact/suggest-compact.sh`) — filed for a follow-up small PR.
+
+## Deferred net-new ECC features (carry forward)
+
+New items added to the deferred queue this round:
+
+- Blender motion-state inspection skill (community contribution)
+- Harness-audit integration scoring extension (ECC PR #1990) — GitHub-integration checks, CODEOWNERS coverage, dynamic applicable-category metadata
+- `continuous-learning-v2` project-registry maintenance — pending `detect-project.sh` decision in EGC
+
+Carried over from prior rounds (still deferred):
+
+- `uncloud` skill (community contribution, round 5)
+- `recsys-pipeline-architect` skill (community contribution, round 5)
+- Thai (`th`) README + docs locale (round 5)
+- Japanese (`ja-JP`) full documentation translation (round 5)
+- Installer `--locale` flag for selective translated-docs installation (round 5)
+- TypeScript 6 + @types/node 25 toolchain bumps (round 5)
+- Zed install target (round 5; most likely permanent-skip)
+- All items still pending from rounds 1–4
+
+## Baseline advance
+
+- **Before**: `3b7e0ba3` (2026-05-18)
+- **After**: `1e8c7e7` (2026-05-21)
+
+Baseline files updated in the same commit set:
+- `upstream/.upstream-sync.json` — `lastSyncedSha` / `lastSyncedAt` / `notes`
+- `upstream/README.md` — Baseline badge, last-synced commit link, last-synced date, round-notes pointer list
+
+Localised mirrors (`upstream/ko-KR/`, `upstream/zh-CN/`) follow the same baseline. As with rounds 4 and 5, this round's per-commit disposition table is published in English only; a localised bucket-level summary can be added on request.

--- a/upstream/sync-rounds/2026-05-26.md
+++ b/upstream/sync-rounds/2026-05-26.md
@@ -41,7 +41,9 @@ Net effect: two more high-value security/robustness fixes landed in ECC main dur
 | X:learning — `bc519e5` continuous-learning-v2 project registry maintenance | 1 | **deferred** — 757-line change. EGC has `observe.sh` + `instinct-cli.py` but no `detect-project.sh`; non-trivial adapter work |
 | **Total** | **102** | |
 
-## Detailed dispositions (the non-skip subset)
+## Detailed dispositions (notable commits)
+
+Includes the portable/deferred candidates plus the out-of-surface fixes whose skip rationale is worth recording for traceability; pure ECC release/ops-log commits are bucketed above and not enumerated individually.
 
 | SHA | Subject | Disposition |
 |---|---|---|
@@ -101,7 +103,7 @@ Carried over from prior rounds (still deferred):
 ## Baseline advance
 
 - **Before**: `3b7e0ba3` (2026-05-18)
-- **After**: `1e8c7e7` (2026-05-21)
+- **After**: `1e8c7e7` (2026-05-20)
 
 Baseline files updated in the same commit set:
 - `upstream/.upstream-sync.json` — `lastSyncedSha` / `lastSyncedAt` / `notes`

--- a/upstream/zh-CN/README.md
+++ b/upstream/zh-CN/README.md
@@ -4,7 +4,7 @@
 
 ![Upstream Sync](https://img.shields.io/badge/Upstream_Sync-Best_effort-blue)
 ![Upstream](https://img.shields.io/badge/upstream-affaan--m%2Feverything--claude--code-informational)
-![Baseline](https://img.shields.io/badge/baseline-393d397e-informational)
+![Baseline](https://img.shields.io/badge/baseline-1e8c7e7-informational)
 
 EGC (Everything Gemini Code) 是 [@affaan-m](https://github.com/affaan-m) 的 [ECC (Everything Claude Code)](https://github.com/affaan-m/everything-claude-code) 的**生态系统移植版本（ecosystem port）**。它不是 ECC 的官方发行版，也不声称与 ECC 在 API 或行为层面兼容。涉及 harness 自身的行为以 Gemini CLI 内部验证为准，不参照 ECC 在 Claude Code 中的表现。
 
@@ -15,9 +15,9 @@ EGC (Everything Gemini Code) 是 [@affaan-m](https://github.com/affaan-m) 的 [E
 ## 上游基线
 
 - **上游仓库**: [`affaan-m/everything-claude-code`](https://github.com/affaan-m/everything-claude-code)
-- **最近一次同步的提交**: [`393d397efa40a9e9b6c7296df8181860ebf5047e`](https://github.com/affaan-m/everything-claude-code/commit/393d397efa40a9e9b6c7296df8181860ebf5047e)
-- **最近一次同步的日期**: 2026-05-13
-- **回合记录**: 最新回合见 [`sync-rounds/2026-05-13.md`](../sync-rounds/2026-05-13.md)，首次 triage 见 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md)。上面的 SHA 是*评估到*的最后一个提交；并非所有进入焦点范围的提交都被移植。
+- **最近一次同步的提交**: [`1e8c7e7994223e0ff337d1626cd08e04a1ae67ed`](https://github.com/affaan-m/everything-claude-code/commit/1e8c7e7994223e0ff337d1626cd08e04a1ae67ed)
+- **最近一次同步的日期**: 2026-05-26
+- **回合记录**: 最新回合见 [`sync-rounds/2026-05-26.md`](../sync-rounds/2026-05-26.md)，往前依次见 [`sync-rounds/2026-05-18.md`](../sync-rounds/2026-05-18.md)、[`sync-rounds/2026-05-15.md`](../sync-rounds/2026-05-15.md)、[`sync-rounds/2026-05-13.md`](../sync-rounds/2026-05-13.md)，首次 triage 见 [`sync-rounds/2026-05-12.md`](../sync-rounds/2026-05-12.md)。上面的 SHA 是*评估到*的最后一个提交；并非所有进入焦点范围的提交都被移植。
 - **EGC 的首次提交**: [`ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35`](https://github.com/Jamkris/everything-gemini-code/commit/ff331996a061c2bbd17ffaa23d4eed2dcdd6ad35) (2026-02-09)
 
 该状态的机器可读副本位于 [`.upstream-sync.json`](../.upstream-sync.json)。CI 校验器 (`scripts/ci/validate-upstream-sync.js`) 会断言两个文件中的 SHA 一致；不一致的 PR 将被自动阻拦。


### PR DESCRIPTION
## Summary

Sixth upstream sync round. Advances the recorded baseline from `3b7e0ba3` (2026-05-18) to `1e8c7e7` (2026-05-20 UTC, evaluated 2026-05-26), closing tracker issue #87 on the next `upstream-drift.yml` tick. 102 commits triaged; per-commit dispositions land in [`upstream/sync-rounds/2026-05-26.md`](https://github.com/Jamkris/everything-gemini-code/blob/docs/upstream-sync-round-2026-05-26/upstream/sync-rounds/2026-05-26.md).

**Headlines:**

- **Two EGC-authored PRs landed upstream during this window**, both ECC-only surface (not back-portable):
  - ECC [PR #1982](https://github.com/affaan-m/everything-claude-code/pull/1982) — Unicode Tag block (`U+E0000–U+E007F`) + six other invisible code points added to `check-unicode-safety.js` denylist. Canonical "ASCII smuggling" / "Tag Smuggling" LLM prompt-injection vector. Validator does not exist in EGC's port surface.
  - ECC [PR #1983](https://github.com/affaan-m/everything-claude-code/pull/1983) — `writeBridgeAtomic` / `writeWarnState` ENOENT race + Windows EPERM/EACCES/EBUSY rename retry. Touches the `ecc-metrics-bridge` / `ecc-context-monitor` cost-observability surface, which is not part of EGC.
- **78 of 102 commits are ECC release-readiness / billing-readback / dashboard refresh / video-suite operations log** (May 18–20 RC1 publication cycle, ECC 2.0 hypergrowth lane) with no EGC analogue — clean skip.
- **9 out-of-surface fixes skip cleanly**: `claude-project` install-target trio, Python LLM providers (OpenAI/AstraFlow empty-choices guard), MCP health-check 406 handling, `gateguard-fact-force` quoting, IOC deny-rule filter, `resolve-ecc-root.js` plugin bootstrap.
- **Three substantial net-new items deferred to focused follow-up PRs:**
  - Blender motion-state inspection skill (community contribution)
  - Harness-audit integration scoring extension (ECC [PR #1990](https://github.com/affaan-m/everything-claude-code/pull/1990), +214 LOC in script / +192 LOC in tests / .md→.toml command translation needed)
  - `continuous-learning-v2` project-registry maintenance (757-line change; EGC missing `detect-project.sh`)
- **One trivial clean-delete portable candidate** (`812d4d0` — delete `skills/strategic-compact/suggest-compact.sh`, unreferenced in EGC's runtime path) filed for a small follow-up PR rather than bundled here, so a regression there does not block the baseline cycle.

**No new EGC→ECC PR opens this round** — the two high-value targets are already merged into ECC main, and the remaining commits are out-of-surface or substantial enough to need focused PRs.

## Files changed

- `upstream/.upstream-sync.json` — `lastSyncedSha` / `lastSyncedAt` / `notes` advanced to round 6.
- `upstream/README.md` — Baseline badge, last-synced commit link, last-synced date, round-notes pointer list extended.
- `upstream/ko-KR/README.md`, `upstream/zh-CN/README.md` — **catch-up update**: localised mirrors had been left on the round-3 baseline `393d397e` (2026-05-13); both now point at the round-6 SHA and list the full pointer chain (5 rounds).
- `upstream/sync-rounds/2026-05-26.md` — new round-6 inventory.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 308/308 pass (includes `ci/validate-upstream-sync.test.js` 9/9, all 5 fixture tests)
- [x] `node scripts/ci/validate-upstream-sync.js` — both files reference `1e8c7e7`
- [x] Compare endpoint `3b7e0ba..1e8c7e7` returns `ahead_by: 102` (matches tracker issue #87)
- [x] Baseline badge URL renders against shields.io
- [x] Round-notes pointer paths all resolve from `upstream/README.md` and from both localised READMEs

## Related

- Closes #87 (Upstream Sync tracker — 102 commits ahead since `3b7e0ba`)
- Prior round: #86 (Round 5, baseline `3b7e0ba3`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance the upstream baseline and publish round‑6 notes to keep EGC in sync with ECC. Tidy the round‑6 notes (rename the “Detailed dispositions” section and correct the footer date to 2026‑05‑20), update `upstream/.upstream-sync.json` and localized READMEs (ko‑KR, zh‑CN), and add `upstream/sync-rounds/2026-05-26.md`; no runtime changes; closes #87.

<sup>Written for commit aa1eae77089bfbfb48e180d6dcded32b5b39fdcc. Summary will update on new commits. <a href="https://cubic.dev/pr/Jamkris/everything-gemini-code/pull/88?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated upstream synchronization docs across languages (en, ko-KR, zh-CN) and added the 2026-05-26 sync round report detailing drift, dispositions, and follow-up items.

* **Chores**
  * Advanced upstream synchronization to round six and updated baseline tracking metadata and round notes to reflect the latest sync.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jamkris/everything-gemini-code/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->