### PR TITLE
chore: release v1.3.15

### DIFF
--- a/.gemini-plugin/plugin.json
+++ b/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.14",
+	"version": "1.3.15",
 	"description": "Complete collection of battle-tested Gemini CLI configurations - agents, skills, hooks, and rules evolved over 10+ months of intensive daily use",
 	"author": {
 		"name": "Jamkris",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.14",
+	"version": "1.3.15",
 	"description": "Complete collection of Gemini CLI configurations adapted from everything-gemini-code - agents, skills, hooks, and rules",
 	"author": {
 		"name": "Jamkris",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "everything-gemini-code",
-	"version": "1.3.14",
+	"version": "1.3.15",
 	"private": true,
 	"description": "Battle-tested Gemini CLI configurations",
 	"author": "Jamkris",


### PR DESCRIPTION
Bump version to 1.3.15

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v1.3.15 release by updating version fields in `package.json`, `.gemini-plugin/plugin.json`, and `gemini-extension.json`. No functional changes.

<sup>Written for commit 48d08904696700389b9d7ab20f7e996dc914dfbc. Summary will update on new commits. <a href="https://cubic.dev/pr/Jamkris/everything-gemini-code/pull/89?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

